### PR TITLE
Merge multiple requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@ client.list_projects()
 ```
 
 ## Development
-### Install
-```
-$ pip install -r requirements-dev.txt
-```
-
 ### Tests
 #### Unit test
 ```
@@ -45,6 +40,7 @@ $ docker-compose down
 ```
 
 ### Lint
+- [PEP 8](https://www.python.org/dev/peps/pep-0008)
 ```
 $ black .
 ```

--- a/centraldogma/exceptions.py
+++ b/centraldogma/exceptions.py
@@ -11,7 +11,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from requests import Response
+from httpx import Response
 
 
 class CentralDogmaException(Exception):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,0 @@
-black
-pytest
-setuptools
-respx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
 dataclasses-json
 httpx[http2]
 marshmallow
+
+# Dev dependencies
+black
+pytest
+setuptools
+respx

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -70,7 +70,6 @@ def test_request_with_configs(respx_mock):
             timeout=5,
             cookies=None,
             auth=None,
-            allow_redirects=False,
         )
         client.request(method, "/path", timeout=(3.05, 27))
         client_with_configs.request(method, "/path")


### PR DESCRIPTION
Motivation
- Merge multiple requirements.txt as PyCharm has no ability to specify multiple requirements.txt files.

Modifications
- Remove `requirements-dev.txt`.
- Misc.
  - Link PEP-8 for `black`.
  - Fix the wrong import, `requests`, in `CentralDogmaException`.

Result
- Fixes #12 