### PR TITLE
Implement `watch_file` and `watch_repository`

### DIFF
--- a/.github/workflows/central-dogma.yml
+++ b/.github/workflows/central-dogma.yml
@@ -6,8 +6,6 @@ on:
     branches:
        - main
   pull_request:
-    branches:
-       - main
 
 jobs:
   build:

--- a/centraldogma/base_client.py
+++ b/centraldogma/base_client.py
@@ -40,7 +40,9 @@ class BaseClient:
         return self._httpx_request(method, path, **kwargs)
 
     def _set_request_headers(self, method: str, **kwargs) -> Dict:
-        kwargs["headers"] = self.patch_headers if method == "patch" else self.headers
+        default_headers = self.patch_headers if method == "patch" else self.headers
+        headers = kwargs.get("headers")
+        kwargs["headers"] = dict(list(default_headers.items()) + list(headers.items())) if headers else default_headers
         return kwargs
 
     def _httpx_request(self, method: str, url: str, **kwargs) -> Response:

--- a/centraldogma/base_client.py
+++ b/centraldogma/base_client.py
@@ -42,7 +42,11 @@ class BaseClient:
     def _set_request_headers(self, method: str, **kwargs) -> Dict:
         default_headers = self.patch_headers if method == "patch" else self.headers
         headers = kwargs.get("headers")
-        kwargs["headers"] = dict(list(default_headers.items()) + list(headers.items())) if headers else default_headers
+        kwargs["headers"] = (
+            dict(list(default_headers.items()) + list(headers.items()))
+            if headers
+            else default_headers
+        )
         return kwargs
 
     def _httpx_request(self, method: str, url: str, **kwargs) -> Response:

--- a/centraldogma/base_client.py
+++ b/centraldogma/base_client.py
@@ -51,12 +51,7 @@ class BaseClient:
 
     def _set_request_headers(self, method: str, **kwargs) -> Dict:
         default_headers = self.patch_headers if method == "patch" else self.headers
-        headers = kwargs.get("headers")
-        kwargs["headers"] = (
-            dict(list(default_headers.items()) + list(headers.items()))
-            if headers
-            else default_headers
-        )
+        kwargs["headers"] = {**default_headers, **(kwargs.get("headers") or {})}
         return kwargs
 
     @staticmethod

--- a/centraldogma/content_service.py
+++ b/centraldogma/content_service.py
@@ -150,7 +150,7 @@ class ContentService:
         content = json["content"]
         if query_type == QueryType.IDENTITY_TEXT:
             return Entry.text(revision, entry_path, content)
-        elif query_type == QueryType.IDENTITY or query_type == QueryType.JSON_PATH:
+        elif query_type == QueryType.IDENTITY_JSON or query_type == QueryType.JSON_PATH:
             if received_entry_type != EntryType.JSON:
                 raise CentralDogmaException(
                     f"invalid entry type. entry type: {received_entry_type} (expected: {query_type})"

--- a/centraldogma/content_service.py
+++ b/centraldogma/content_service.py
@@ -30,7 +30,7 @@ from centraldogma.data.revision import Revision
 from centraldogma.exceptions import CentralDogmaException
 from centraldogma.query import Query, QueryType
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 class ContentService:
@@ -38,12 +38,12 @@ class ContentService:
         self.client = client
 
     def get_files(
-            self,
-            project_name: str,
-            repo_name: str,
-            path_pattern: Optional[str],
-            revision: Optional[int],
-            include_content: bool = False,
+        self,
+        project_name: str,
+        repo_name: str,
+        path_pattern: Optional[str],
+        revision: Optional[int],
+        include_content: bool = False,
     ) -> List[Content]:
         params = {"revision": revision} if revision else None
         path = f"/projects/{project_name}/repos/{repo_name}/"
@@ -78,11 +78,11 @@ class ContentService:
         return Content.from_dict(resp.json())
 
     def push(
-            self,
-            project_name: str,
-            repo_name: str,
-            commit: Commit,
-            changes: List[Change],
+        self,
+        project_name: str,
+        repo_name: str,
+        commit: Commit,
+        changes: List[Change],
     ) -> PushResult:
         params = {
             "commitMessage": asdict(commit),
@@ -95,13 +95,19 @@ class ContentService:
         json: object = resp.json()
         return PushResult.from_dict(json)
 
-    def watch_repository(self, project_name: str, repo_name: str, last_known_revision: Revision, path_pattern: str,
-                         timeout_millis: int) -> Optional[Revision]:
+    def watch_repository(
+        self,
+        project_name: str,
+        repo_name: str,
+        last_known_revision: Revision,
+        path_pattern: str,
+        timeout_millis: int,
+    ) -> Optional[Revision]:
         path = f"/projects/{project_name}/repos/{repo_name}/contents"
         if path_pattern[0] != "/":
             path += "/**/"
 
-        if path_pattern in ' ':
+        if path_pattern in " ":
             path_pattern = path_pattern.replace(" ", "%20")
         path += path_pattern
 
@@ -115,8 +121,14 @@ class ContentService:
             # TODO(ikhoon): Handle excepitons after https://github.com/line/centraldogma-python/pull/11/ is merged.
             pass
 
-    def watch_file(self, project_name: str, repo_name: str, last_known_revision: Revision, query: Query[T],
-                   timeout_millis) -> Optional[Entry[T]]:
+    def watch_file(
+        self,
+        project_name: str,
+        repo_name: str,
+        last_known_revision: Revision,
+        query: Query[T],
+        timeout_millis,
+    ) -> Optional[Entry[T]]:
         path = f"/projects/{project_name}/repos/{repo_name}/contents/{query.path}"
         if query.query_type == QueryType.JSON_PATH:
             queries = [f"jsonpath={quote(expr)}" for expr in query.expressions]
@@ -143,7 +155,8 @@ class ContentService:
         elif query_type == QueryType.IDENTITY or query_type == QueryType.JSON_PATH:
             if received_entry_type != EntryType.JSON:
                 raise CentralDogmaException(
-                    f"invalid entry type. entry type: {received_entry_type} (expected: {query_type})")
+                    f"invalid entry type. entry type: {received_entry_type} (expected: {query_type})"
+                )
 
             return Entry.json(revision, entry_path, content)
         else:  # query_type == QueryType.IDENTITY
@@ -155,16 +168,16 @@ class ContentService:
                 return Entry.directory(revision, entry_path)
 
     def _watch(
-            self,
-            last_known_revision: Revision,
-            timeout_millis: int,
-            path: str) -> Response:
+        self, last_known_revision: Revision, timeout_millis: int, path: str
+    ) -> Response:
         normalized_timeout = (timeout_millis + 999) // 1000
         headers = {
             "if-none-match": f"{last_known_revision.major}",
-            "prefer": f"wait={normalized_timeout}"
+            "prefer": f"wait={normalized_timeout}",
         }
-        return self.client.request("get", path, headers=headers, timeout=normalized_timeout)
+        return self.client.request(
+            "get", path, headers=headers, timeout=normalized_timeout
+        )
 
     def _change_dict(self, data):
         return {

--- a/centraldogma/content_service.py
+++ b/centraldogma/content_service.py
@@ -112,7 +112,7 @@ class ContentService:
         if path_pattern[0] != "/":
             path += "/**/"
 
-        if path_pattern in " ":
+        if " " in path_pattern:
             path_pattern = path_pattern.replace(" ", "%20")
         path += path_pattern
 
@@ -157,12 +157,12 @@ class ContentService:
                 )
 
             return Entry.json(revision, entry_path, content)
-        else:  # query_type == QueryType.IDENTITY
+        elif query_type == QueryType.IDENTITY:
             if received_entry_type == EntryType.JSON:
                 return Entry.json(revision, entry_path, content)
             elif received_entry_type == EntryType.TEXT:
                 return Entry.text(revision, entry_path, content)
-            else:  # received_entry_type == EntryType.DIRECTORY
+            elif received_entry_type == EntryType.DIRECTORY:
                 return Entry.directory(revision, entry_path)
 
     def _watch(

--- a/centraldogma/content_service.py
+++ b/centraldogma/content_service.py
@@ -128,7 +128,7 @@ class ContentService:
         repo_name: str,
         last_known_revision: Revision,
         query: Query[T],
-        timeout_millis,
+        timeout_millis: int,
     ) -> Optional[Entry[T]]:
         path = f"/projects/{project_name}/repos/{repo_name}/contents/{query.path}"
         if query.query_type == QueryType.JSON_PATH:

--- a/centraldogma/content_service.py
+++ b/centraldogma/content_service.py
@@ -82,6 +82,7 @@ class ContentService:
         project_name: str,
         repo_name: str,
         commit: Commit,
+        # TODO(ikhoon): Make changes accept varargs?
         changes: List[Change],
     ) -> PushResult:
         params = {

--- a/centraldogma/data/change.py
+++ b/centraldogma/data/change.py
@@ -31,4 +31,4 @@ class ChangeType(Enum):
 class Change:
     path: str
     type: ChangeType
-    content: Optional[Union[map, str]] = None
+    content: Optional[Union[dict, str]] = None

--- a/centraldogma/data/entry.py
+++ b/centraldogma/data/entry.py
@@ -50,7 +50,7 @@ class Entry(Generic[T]):
     @staticmethod
     def json(revision: Revision, path: str, content: Any) -> Entry[Any]:
         """
-         Returns a newly-created {@link Entry} of a JSON file.
+         Returns a newly-created ``Entry`` of a JSON file.
 
         :param revision: the revision of the JSON file
         :param path: the path of the JSON file
@@ -63,7 +63,7 @@ class Entry(Generic[T]):
     @staticmethod
     def directory(revision: Revision, path: str) -> Entry[None]:
         """
-        Returns a newly-created {@link Entry} of a directory.
+        Returns a newly-created ``Entry`` of a directory.
 
         :param revision: the revision of the directory
         :param path: the path of the directory

--- a/centraldogma/data/entry.py
+++ b/centraldogma/data/entry.py
@@ -1,0 +1,77 @@
+#  Copyright 2021 LINE Corporation
+#
+#  LINE Corporation licenses this file to you under the Apache License,
+#  version 2.0 (the "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+from __future__ import annotations
+
+import json
+from enum import Enum, auto
+from typing import TypeVar, Generic, Any
+
+from centraldogma.data.revision import Revision
+from centraldogma.exceptions import EntryNoContentException
+
+
+class EntryType(Enum):
+    JSON = auto()
+    TEXT = auto()
+    DIRECTORY = auto()
+
+
+T = TypeVar('T')
+
+
+class Entry(Generic[T]):
+
+    @staticmethod
+    def text(revision: Revision, path: str, content: str) -> Entry[str]:
+        return Entry(revision, path, EntryType.TEXT, content)
+
+    @staticmethod
+    def json(revision: Revision, path: str, content: Any) -> Entry[Any]:
+        if type(content) is str:
+            content = json.loads(content)
+        return Entry(revision, path, EntryType.JSON, content)
+
+    @staticmethod
+    def directory(revision: Revision, path: str) -> Entry[None]:
+        return Entry(revision, path, EntryType.DIRECTORY, None)
+
+    def __init__(self, revision: Revision, path: str, entry_type: EntryType, content: T):
+        self.revision = revision
+        self.path = path
+        self.entry_type = entry_type
+        self._content = content
+        self._content_as_text = None
+
+    def has_content(self) -> bool:
+        return self.content is not None
+
+    @property
+    def content(self) -> T:
+        if self._content is None:
+            raise EntryNoContentException(f"{self.path} (type: {self.entry_type}, revision: {self.revision.major})")
+
+        return self._content
+
+    def content_as_text(self) -> str:
+        if self._content_as_text is not None:
+            return self._content_as_text
+
+        if self.entry_type == EntryType.TEXT:
+            self._content_as_text = self.content
+        elif self.entry_type == EntryType.DIRECTORY:
+            self._content_as_text = ''
+        else:
+            self._content_as_text = json.dumps(self.content)
+
+        return self._content_as_text

--- a/centraldogma/data/entry.py
+++ b/centraldogma/data/entry.py
@@ -17,6 +17,7 @@ import json
 from enum import Enum, auto
 from typing import TypeVar, Generic, Any
 
+from centraldogma import util
 from centraldogma.data.revision import Revision
 from centraldogma.exceptions import EntryNoContentException
 
@@ -31,18 +32,42 @@ T = TypeVar("T")
 
 
 class Entry(Generic[T]):
+    """
+    A file or a directory in a repository.
+    """
+
     @staticmethod
     def text(revision: Revision, path: str, content: str) -> Entry[str]:
+        """
+        Returns a newly-created ``Entry`` of a text file.
+
+        :param revision: the revision of the text file
+        :param path: the path of the text file
+        :param content: the content of the text file
+        """
         return Entry(revision, path, EntryType.TEXT, content)
 
     @staticmethod
     def json(revision: Revision, path: str, content: Any) -> Entry[Any]:
+        """
+         Returns a newly-created {@link Entry} of a JSON file.
+
+        :param revision: the revision of the JSON file
+        :param path: the path of the JSON file
+        :param content: the content of the JSON file
+        """
         if type(content) is str:
             content = json.loads(content)
         return Entry(revision, path, EntryType.JSON, content)
 
     @staticmethod
     def directory(revision: Revision, path: str) -> Entry[None]:
+        """
+        Returns a newly-created {@link Entry} of a directory.
+
+        :param revision: the revision of the directory
+        :param path: the path of the directory
+        """
         return Entry(revision, path, EntryType.DIRECTORY, None)
 
     def __init__(
@@ -55,10 +80,18 @@ class Entry(Generic[T]):
         self._content_as_text = None
 
     def has_content(self) -> bool:
+        """
+        Returns if this ``Entry`` has content, which is always ``True`` if it's not a directory.
+        """
         return self.content is not None
 
     @property
     def content(self) -> T:
+        """
+        Returns the content.
+
+        :exception EntryNoContentException if the content is ``None``
+        """
         if self._content is None:
             raise EntryNoContentException(
                 f"{self.path} (type: {self.entry_type}, revision: {self.revision.major})"
@@ -67,14 +100,24 @@ class Entry(Generic[T]):
         return self._content
 
     def content_as_text(self) -> str:
+        """
+        Returns the textual representation of the specified content.
+
+        :exception EntryNoContentException if the content is ``None``
+        """
         if self._content_as_text is not None:
             return self._content_as_text
 
+        content = self.content
         if self.entry_type == EntryType.TEXT:
-            self._content_as_text = self.content
-        elif self.entry_type == EntryType.DIRECTORY:
-            self._content_as_text = ""
+            self._content_as_text = content
         else:
             self._content_as_text = json.dumps(self.content)
 
         return self._content_as_text
+
+    def __str__(self) -> str:
+        return util.to_string(self)
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/centraldogma/data/entry.py
+++ b/centraldogma/data/entry.py
@@ -23,9 +23,9 @@ from centraldogma.exceptions import EntryNoContentException
 
 
 class EntryType(Enum):
-    JSON = auto()
-    TEXT = auto()
-    DIRECTORY = auto()
+    JSON = "JSON"
+    TEXT = "TEXT"
+    DIRECTORY = "DIRECTORY"
 
 
 T = TypeVar("T")

--- a/centraldogma/data/entry.py
+++ b/centraldogma/data/entry.py
@@ -27,11 +27,10 @@ class EntryType(Enum):
     DIRECTORY = auto()
 
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 class Entry(Generic[T]):
-
     @staticmethod
     def text(revision: Revision, path: str, content: str) -> Entry[str]:
         return Entry(revision, path, EntryType.TEXT, content)
@@ -46,7 +45,9 @@ class Entry(Generic[T]):
     def directory(revision: Revision, path: str) -> Entry[None]:
         return Entry(revision, path, EntryType.DIRECTORY, None)
 
-    def __init__(self, revision: Revision, path: str, entry_type: EntryType, content: T):
+    def __init__(
+        self, revision: Revision, path: str, entry_type: EntryType, content: T
+    ):
         self.revision = revision
         self.path = path
         self.entry_type = entry_type
@@ -59,7 +60,9 @@ class Entry(Generic[T]):
     @property
     def content(self) -> T:
         if self._content is None:
-            raise EntryNoContentException(f"{self.path} (type: {self.entry_type}, revision: {self.revision.major})")
+            raise EntryNoContentException(
+                f"{self.path} (type: {self.entry_type}, revision: {self.revision.major})"
+            )
 
         return self._content
 
@@ -70,7 +73,7 @@ class Entry(Generic[T]):
         if self.entry_type == EntryType.TEXT:
             self._content_as_text = self.content
         elif self.entry_type == EntryType.DIRECTORY:
-            self._content_as_text = ''
+            self._content_as_text = ""
         else:
             self._content_as_text = json.dumps(self.content)
 

--- a/centraldogma/data/entry.py
+++ b/centraldogma/data/entry.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 import json
-from enum import Enum, auto
+from enum import Enum
 from typing import TypeVar, Generic, Any
 
 from centraldogma import util

--- a/centraldogma/data/entry.py
+++ b/centraldogma/data/entry.py
@@ -92,7 +92,7 @@ class Entry(Generic[T]):
 
         :exception EntryNoContentException if the content is ``None``
         """
-        if self._content is None:
+        if not self._content:
             raise EntryNoContentException(
                 f"{self.path} (type: {self.entry_type}, revision: {self.revision.major})"
             )
@@ -105,7 +105,7 @@ class Entry(Generic[T]):
 
         :exception EntryNoContentException if the content is ``None``
         """
-        if self._content_as_text is not None:
+        if self._content_as_text:
             return self._content_as_text
 
         content = self.content

--- a/centraldogma/data/revision.py
+++ b/centraldogma/data/revision.py
@@ -1,0 +1,19 @@
+#  Copyright 2021 LINE Corporation
+#
+#  LINE Corporation licenses this file to you under the Apache License,
+#  version 2.0 (the "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+from dataclasses import dataclass
+
+
+@dataclass
+class Revision:
+    major: int

--- a/centraldogma/data/revision.py
+++ b/centraldogma/data/revision.py
@@ -11,9 +11,24 @@
 #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #  License for the specific language governing permissions and limitations
 #  under the License.
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 
 @dataclass
 class Revision:
-    major: int
+    def __init__(self, major):
+        self.major = major
+
+    @staticmethod
+    def init() -> Revision:
+        return _INIT
+
+    @staticmethod
+    def head() -> Revision:
+        return _HEAD
+
+
+_INIT = Revision(1)
+_HEAD = Revision(-1)

--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -11,6 +11,9 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import os
+from typing import List, Optional, TypeVar, Generic
+
 from centraldogma.base_client import BaseClient
 from centraldogma.content_service import ContentService
 from centraldogma.data import (
@@ -22,13 +25,16 @@ from centraldogma.data import (
     PushResult,
     Repository,
 )
+from centraldogma.data.entry import Entry
+from centraldogma.data.revision import Revision
 from centraldogma.project_service import ProjectService
+from centraldogma.query import Query
 from centraldogma.repository_service import RepositoryService
-from typing import List, Optional
-import os
+
+T = TypeVar('T')
 
 
-class Dogma:
+class Dogma(Generic[T]):
     DEFAULT_BASE_URL = "http://localhost:36462"
     DEFAULT_TOKEN = "anonymous"
 
@@ -179,3 +185,29 @@ class Dogma:
             the content is supposed to be the new name.
         """
         return self.content_service.push(project_name, repo_name, commit, changes)
+
+    def watch_repository(
+            self,
+            project_name: str,
+            repo_name: str,
+            last_known_revision: Revision,
+            path_pattern: str,
+            timeout_millis: int) -> Optional[Revision]:
+        """
+        TODO(ikhoon): TBU
+        """
+        return self.content_service.watch_repository(project_name, repo_name, last_known_revision,
+                                                     path_pattern, timeout_millis)
+
+    def watch_file(
+            self,
+            project_name: str,
+            repo_name: str,
+            last_known_revision: Revision,
+            query: Query[T],
+            timeout_millis: int) -> Optional[Entry[T]]:
+        """
+        TODO(ikhoon): TBU
+        :rtype: object
+        """
+        return self.content_service.watch_file(project_name, repo_name, last_known_revision, query, timeout_millis)

--- a/centraldogma/exceptions.py
+++ b/centraldogma/exceptions.py
@@ -45,3 +45,8 @@ class UnauthorizedException(CentralDogmaException):
 
 class UnknownException(CentralDogmaException):
     pass
+
+
+class EntryNoContentException(CentralDogmaException):
+    """A CentralDogmaException that is raised when attempted to retrieve the content from a directory entry."""
+    pass

--- a/centraldogma/exceptions.py
+++ b/centraldogma/exceptions.py
@@ -49,4 +49,5 @@ class UnknownException(CentralDogmaException):
 
 class EntryNoContentException(CentralDogmaException):
     """A CentralDogmaException that is raised when attempted to retrieve the content from a directory entry."""
+
     pass

--- a/centraldogma/query.py
+++ b/centraldogma/query.py
@@ -1,0 +1,51 @@
+#  Copyright 2021 LINE Corporation
+#
+#  LINE Corporation licenses this file to you under the Apache License,
+#  version 2.0 (the "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+from __future__ import annotations
+
+from enum import Enum, auto
+from typing import TypeVar, Generic, Any, List
+
+
+class QueryType(Enum):
+    IDENTITY = auto()
+    IDENTITY_TEXT = auto()
+    IDENTITY_JSON = auto()
+    JSON_PATH = auto()
+
+
+T = TypeVar('T')
+
+
+class Query(Generic[T]):
+
+    @staticmethod
+    def identity(path: str) -> Query[str]:
+        return Query(path=path, query_type=QueryType.IDENTITY, expressions=[])
+
+    @staticmethod
+    def text(path: str) -> Query[str]:
+        return Query(path=path, query_type=QueryType.IDENTITY_TEXT, expressions=[])
+
+    @staticmethod
+    def json(path: str) -> Query[Any]:
+        return Query(path=path, query_type=QueryType.IDENTITY_JSON, expressions=[])
+
+    @staticmethod
+    def json_path(path: str, json_paths: List[str]) -> Query[Any]:
+        return Query(path=path, query_type=QueryType.JSON_PATH, expressions=json_paths)
+
+    def __init__(self, path: str, query_type: QueryType, expressions: List[str]):
+        self.path = path
+        self.query_type = query_type
+        self.expressions = expressions

--- a/centraldogma/query.py
+++ b/centraldogma/query.py
@@ -13,8 +13,8 @@
 #  under the License.
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import Enum, auto
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import TypeVar, Generic, Any, List
 
 
@@ -36,7 +36,7 @@ class Query(Generic[T]):
 
     path: str
     query_type: QueryType
-    expressions: List[str]
+    expressions: List[str] = field(default_factory=list)
 
     @staticmethod
     def identity(path: str) -> Query[str]:
@@ -45,7 +45,7 @@ class Query(Generic[T]):
 
         :param path: the path of a file being queried on
         """
-        return Query(path=path, query_type=QueryType.IDENTITY, expressions=[])
+        return Query(path=path, query_type=QueryType.IDENTITY)
 
     @staticmethod
     def text(path: str) -> Query[str]:
@@ -54,7 +54,7 @@ class Query(Generic[T]):
 
         :param path: the path of a file being queried on
         """
-        return Query(path=path, query_type=QueryType.IDENTITY_TEXT, expressions=[])
+        return Query(path=path, query_type=QueryType.IDENTITY_TEXT)
 
     @staticmethod
     def json(path: str) -> Query[Any]:
@@ -63,7 +63,7 @@ class Query(Generic[T]):
 
         :param path: the path of a file being queried on
         """
-        return Query(path=path, query_type=QueryType.IDENTITY_JSON, expressions=[])
+        return Query(path=path, query_type=QueryType.IDENTITY_JSON)
 
     @staticmethod
     def json_path(path: str, json_paths: List[str]) -> Query[Any]:

--- a/centraldogma/query.py
+++ b/centraldogma/query.py
@@ -13,6 +13,7 @@
 #  under the License.
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum, auto
 from typing import TypeVar, Generic, Any, List
 
@@ -27,7 +28,12 @@ class QueryType(Enum):
 T = TypeVar("T")
 
 
+@dataclass
 class Query(Generic[T]):
+    path: str
+    query_type: QueryType
+    expressions: List[str]
+
     @staticmethod
     def identity(path: str) -> Query[str]:
         return Query(path=path, query_type=QueryType.IDENTITY, expressions=[])
@@ -43,8 +49,3 @@ class Query(Generic[T]):
     @staticmethod
     def json_path(path: str, json_paths: List[str]) -> Query[Any]:
         return Query(path=path, query_type=QueryType.JSON_PATH, expressions=json_paths)
-
-    def __init__(self, path: str, query_type: QueryType, expressions: List[str]):
-        self.path = path
-        self.query_type = query_type
-        self.expressions = expressions

--- a/centraldogma/query.py
+++ b/centraldogma/query.py
@@ -30,22 +30,47 @@ T = TypeVar("T")
 
 @dataclass
 class Query(Generic[T]):
+    """
+    A query on a file.
+    """
+
     path: str
     query_type: QueryType
     expressions: List[str]
 
     @staticmethod
     def identity(path: str) -> Query[str]:
+        """
+        Returns a newly-created ``Query`` that retrieves the content as it is.
+
+        :param path: the path of a file being queried on
+        """
         return Query(path=path, query_type=QueryType.IDENTITY, expressions=[])
 
     @staticmethod
     def text(path: str) -> Query[str]:
+        """
+        Returns a newly-created ``Query`` that retrieves the textual content as it is.
+        :param path: the path of a file being queried on
+        """
         return Query(path=path, query_type=QueryType.IDENTITY_TEXT, expressions=[])
 
     @staticmethod
     def json(path: str) -> Query[Any]:
+        """
+        Returns a newly-created ``Query`` that retrieves the JSON content as it is.
+
+        :param path: the path of a file being queried on
+        """
         return Query(path=path, query_type=QueryType.IDENTITY_JSON, expressions=[])
 
     @staticmethod
     def json_path(path: str, json_paths: List[str]) -> Query[Any]:
+        """
+        Returns a newly-created ``Query`` that applies a series of
+        `JSON path expressions <https://github.com/json-path/JsonPath/blob/master/README.md>_ to the content.
+
+        :param path: the path of a file being queried on
+        :param json_paths: the JSON path expressions to apply
+        """
         return Query(path=path, query_type=QueryType.JSON_PATH, expressions=json_paths)

--- a/centraldogma/query.py
+++ b/centraldogma/query.py
@@ -51,6 +51,7 @@ class Query(Generic[T]):
     def text(path: str) -> Query[str]:
         """
         Returns a newly-created ``Query`` that retrieves the textual content as it is.
+
         :param path: the path of a file being queried on
         """
         return Query(path=path, query_type=QueryType.IDENTITY_TEXT, expressions=[])

--- a/centraldogma/query.py
+++ b/centraldogma/query.py
@@ -24,11 +24,10 @@ class QueryType(Enum):
     JSON_PATH = auto()
 
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 class Query(Generic[T]):
-
     @staticmethod
     def identity(path: str) -> Query[str]:
         return Query(path=path, query_type=QueryType.IDENTITY, expressions=[])

--- a/centraldogma/query.py
+++ b/centraldogma/query.py
@@ -19,10 +19,10 @@ from typing import TypeVar, Generic, Any, List
 
 
 class QueryType(Enum):
-    IDENTITY = auto()
-    IDENTITY_TEXT = auto()
-    IDENTITY_JSON = auto()
-    JSON_PATH = auto()
+    IDENTITY = "IDENTITY"
+    IDENTITY_TEXT = "IDENTITY_TEXT"
+    IDENTITY_JSON = "IDENTITY_JSON"
+    JSON_PATH = "JSON_PATH"
 
 
 T = TypeVar("T")

--- a/centraldogma/query.py
+++ b/centraldogma/query.py
@@ -69,7 +69,7 @@ class Query(Generic[T]):
     def json_path(path: str, json_paths: List[str]) -> Query[Any]:
         """
         Returns a newly-created ``Query`` that applies a series of
-        `JSON path expressions <https://github.com/json-path/JsonPath/blob/master/README.md>_ to the content.
+        `JSON path expressions <https://github.com/json-path/JsonPath/blob/master/README.md>`_ to the content.
 
         :param path: the path of a file being queried on
         :param json_paths: the JSON path expressions to apply

--- a/centraldogma/repository_watcher.py
+++ b/centraldogma/repository_watcher.py
@@ -1,0 +1,232 @@
+#  Copyright 2021 LINE Corporation
+#
+#  LINE Corporation licenses this file to you under the Apache License,
+#  version 2.0 (the "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+import logging
+import math
+import threading
+import time
+from asyncio import Future
+from enum import Enum, auto
+from random import randrange
+from threading import Thread, Lock
+from typing import TypeVar, Callable, Optional, List
+
+from centraldogma.data.revision import Revision
+from centraldogma.dogma import Dogma
+from centraldogma.query import Query
+from centraldogma.watcher import Watcher, Latest
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+
+class WatchState(Enum):
+    INIT = auto()
+    STARTED = auto()
+    STOPPED = auto()
+
+
+_DELAY_ON_SUCCESS_MILLIS = 1000  # 1 second
+_MIN_INTERVAL_MILLIS = _DELAY_ON_SUCCESS_MILLIS * 2  # 2 seconds
+_MAX_INTERVAL_MILLIS = 1 * 60 * 1000  # 1 minute
+_JITTER_RATE = 0.2
+
+
+class AbstractWatcher(Watcher[T]):
+    _latest: Optional[Latest[T]] = None
+    _state: WatchState = WatchState.INIT
+    _initial_value_future = Future()
+    _update_listeners: List[Callable[[Revision, T], None]] = []
+    _thread: Optional[threading.Thread] = None
+    _lock: Lock = threading.Lock()
+
+    def __init__(
+        self,
+        dogma: Dogma,
+        project_name: str,
+        repo_name: str,
+        path_pattern: str,
+        function: Callable[[S], T],
+    ):
+        self.dogma = dogma
+        self.project_name = project_name
+        self.repo_name = repo_name
+        self.path_pattern = path_pattern
+        self.function = function
+
+    def start(self):
+        with self._lock:
+            if self._state == WatchState.INIT:
+                # FIXME(ikhoon): Replace Thread with Coroutine of asyncio once AsyncClient is implemented.
+                self._thread = Thread(target=self._schedule_watch, args=(0,))
+                self._thread.start()
+
+    def close(self) -> None:
+        self._state = WatchState.STOPPED
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def latest(self) -> Latest[T]:
+        return self._latest
+
+    def watch(self, listener: Callable[[Revision, T], None]) -> None:
+        self._update_listeners.append(listener)
+
+        if self._latest:
+            listener(self._latest.revision, self._latest.value)
+
+    def _schedule_watch(self, num_attempts_so_far: int) -> None:
+        if self._is_stopped():
+            return
+
+        if num_attempts_so_far == 0:
+            delay = _DELAY_ON_SUCCESS_MILLIS if self._latest is None else 0
+        else:
+            delay = self._next_delay_millis(num_attempts_so_far)
+
+        # FIXME(ikhoon): Replace asyncio.sleep() after AsyncClient is implemented.
+        time.sleep(delay / 1000)
+        self._watch(num_attempts_so_far)
+        return None
+
+    def _watch(self, num_attempts_so_far: int) -> None:
+        if self._is_stopped():
+            return
+
+        last_known_revision = self._latest.revision if self._latest else Revision.init()
+        try:
+            new_latest = self._do_watch(last_known_revision)
+            if new_latest:
+                old_latest = self._latest
+                self._latest = new_latest
+                logging.debug(
+                    f"watcher noticed updated file %s/%s%s: rev=%s",
+                    self.project_name,
+                    self.repo_name,
+                    self.path_pattern,
+                    new_latest.revision,
+                )
+                self.notify_listeners()
+                if not old_latest:
+                    self._initial_value_future.set_result(new_latest)
+
+                # Watch again for the next change.
+                self._schedule_watch(0)
+        except Exception as ex:
+            logged = False
+            # TODO(ikhoon): Leave proper log messages
+
+            if not logged:
+                logging.warning(
+                    "Failed to watch a file (%s/%s%s) at Central Dogma; trying again\n%s",
+                    self.project_name,
+                    self.repo_name,
+                    self.path_pattern,
+                    ex,
+                )
+            self._schedule_watch(num_attempts_so_far + 1)
+            return
+
+    def _do_watch(self, last_known_revision) -> Optional[Latest[T]]:
+        pass
+
+    def notify_listeners(self):
+        if self._is_stopped():
+            # Do not notify after stopped.
+            return
+
+        latest = self._latest
+        for listener in self._update_listeners:
+            try:
+                listener(latest.revision, latest.value)
+            except Exception as ex:
+                logging.warning(
+                    "Exception thrown for watcher (%s/%s%s): rev=%s\n%s",
+                    self.project_name,
+                    self.repo_name,
+                    self.path_pattern,
+                    latest.revision,
+                    ex,
+                )
+
+    def _is_stopped(self) -> bool:
+        return self._state == WatchState.STOPPED
+
+    @staticmethod
+    def _next_delay_millis(num_attempts_so_far: int) -> int:
+        if num_attempts_so_far == 1:
+            next_delay_millis = _MIN_INTERVAL_MILLIS
+        else:
+            delay = _MIN_INTERVAL_MILLIS * math.pow(2.0, num_attempts_so_far - 1)
+            next_delay_millis = min(delay, _MAX_INTERVAL_MILLIS)
+
+        min_jitter = int(next_delay_millis * (1 - _JITTER_RATE))
+        max_jitter = int(next_delay_millis * (1 + _JITTER_RATE))
+        bound = max_jitter - min_jitter + 1
+        jitter = randrange(bound)
+        return max(0, min_jitter + jitter)
+
+
+class FileWatcher(AbstractWatcher[T]):
+    def __init__(
+        self,
+        dogma: Dogma,
+        project_name: str,
+        repo_name: str,
+        query: Query[T],
+        function: Callable[[S], T],
+    ):
+        super().__init__(dogma, project_name, repo_name, query.path, function)
+        self.query = query
+
+    def _do_watch(self, last_known_revision) -> Optional[Latest[T]]:
+        # TODO(ikhoon): Set default timeout for watch_file
+        result = self.dogma.watch_file(
+            self.project_name,
+            self.repo_name,
+            last_known_revision,
+            self.query,
+            1 * 60 * 1000,
+        )
+        if not result:
+            return None
+        return Latest(result.revision, self.function(result.content))
+
+
+class RepositoryWatcher(AbstractWatcher[T]):
+    def __init__(
+        self,
+        dogma: Dogma,
+        project_name: str,
+        repo_name: str,
+        path_pattern: str,
+        function: Callable[[Revision], T],
+    ):
+        super().__init__(dogma, project_name, repo_name, path_pattern, function)
+
+    def _do_watch(self, last_known_revision) -> Optional[Latest[T]]:
+        revision = self.dogma.watch_repository(
+            self.project_name,
+            self.repo_name,
+            last_known_revision,
+            self.path_pattern,
+            1 * 60 * 1000,
+        )
+        if not revision:
+            return None
+        return Latest(revision, self.function(revision))

--- a/centraldogma/repository_watcher.py
+++ b/centraldogma/repository_watcher.py
@@ -70,8 +70,12 @@ class AbstractWatcher(Watcher[T]):
         with self._lock:
             if self._state == WatchState.INIT:
                 # FIXME(ikhoon): Replace Thread with Coroutine of asyncio once AsyncClient is implemented.
-                self._thread = Thread(target=self._schedule_watch, args=(0,),
-                                      name=f"centraldogma-watcher-{next(_THREAD_ID)}", daemon=True)
+                self._thread = Thread(
+                    target=self._schedule_watch,
+                    args=(0,),
+                    name=f"centraldogma-watcher-{next(_THREAD_ID)}",
+                    daemon=True,
+                )
                 self._thread.start()
 
     def close(self) -> None:
@@ -198,10 +202,8 @@ class FileWatcher(AbstractWatcher[T]):
 
     def _do_watch(self, last_known_revision) -> Optional[Latest[T]]:
         result = self.dogma.watch_file(
-            self.project_name,
-            self.repo_name,
-            last_known_revision,
-            self.query)
+            self.project_name, self.repo_name, last_known_revision, self.query
+        )
         if not result:
             return None
         return Latest(result.revision, self.function(result.content))
@@ -220,10 +222,8 @@ class RepositoryWatcher(AbstractWatcher[T]):
 
     def _do_watch(self, last_known_revision) -> Optional[Latest[T]]:
         revision = self.dogma.watch_repository(
-            self.project_name,
-            self.repo_name,
-            last_known_revision,
-            self.path_pattern)
+            self.project_name, self.repo_name, last_known_revision, self.path_pattern
+        )
         if not revision:
             return None
         return Latest(revision, self.function(revision))

--- a/centraldogma/repository_watcher.py
+++ b/centraldogma/repository_watcher.py
@@ -37,9 +37,9 @@ T = TypeVar("T")
 
 
 class WatchState(Enum):
-    INIT = auto()
-    STARTED = auto()
-    STOPPED = auto()
+    INIT = "INIT"
+    STARTED = "STARTED"
+    STOPPED = "STOPPED"
 
 
 _DELAY_ON_SUCCESS_MILLIS = 1000  # 1 second
@@ -173,7 +173,7 @@ class AbstractWatcher(Watcher[T]):
             self._schedule_watch(num_attempts_so_far + 1)
             return
 
-    def _do_watch(self, last_known_revision) -> Optional[Latest[T]]:
+    def _do_watch(self, last_known_revision: Revision) -> Optional[Latest[T]]:
         pass
 
     def notify_listeners(self):
@@ -225,7 +225,7 @@ class FileWatcher(AbstractWatcher[T]):
         super().__init__(dogma, project_name, repo_name, query.path, function)
         self.query = query
 
-    def _do_watch(self, last_known_revision) -> Optional[Latest[T]]:
+    def _do_watch(self, last_known_revision: Revision) -> Optional[Latest[T]]:
         result = self.dogma.watch_file(
             self.project_name, self.repo_name, last_known_revision, self.query
         )

--- a/centraldogma/repository_watcher.py
+++ b/centraldogma/repository_watcher.py
@@ -90,6 +90,9 @@ class AbstractWatcher(Watcher[T]):
     def latest(self) -> Latest[T]:
         return self._latest
 
+    def initial_value_future(self) -> Future[Latest[T]]:
+        return self._initial_value_future
+
     def watch(self, listener: Callable[[Revision, T], None]) -> None:
         self._update_listeners.append(listener)
 
@@ -139,7 +142,7 @@ class AbstractWatcher(Watcher[T]):
 
             if not logged:
                 logging.warning(
-                    "Failed to watch a file (%s/%s%s) at Central Dogma; trying again\n%s",
+                    "Failed to watch a file (%s/%s%s) at Central Dogma; trying again.\n%s",
                     self.project_name,
                     self.repo_name,
                     self.path_pattern,
@@ -158,16 +161,16 @@ class AbstractWatcher(Watcher[T]):
 
         latest = self._latest
         for listener in self._update_listeners:
+            # noinspection PyBroadException
             try:
                 listener(latest.revision, latest.value)
             except Exception as ex:
-                logging.warning(
-                    "Exception thrown for watcher (%s/%s%s): rev=%s\n%s",
+                logging.exception(
+                    "Exception thrown for watcher (%s/%s%s): rev=%s.",
                     self.project_name,
                     self.repo_name,
                     self.path_pattern,
                     latest.revision,
-                    ex,
                 )
 
     def _is_stopped(self) -> bool:

--- a/centraldogma/util.py
+++ b/centraldogma/util.py
@@ -13,11 +13,7 @@
 #  under the License.
 
 
-def to_string(obj, **fields) -> str:
+def to_string(obj) -> str:
     items = vars(obj).items()
-    if not fields:
-        values = [f"{k}={v}" for k, v in items]
-    else:
-        values = [f"{k}={v}" for k, v in items if k in fields]
-
+    values = [f"{k}={v}" for k, v in items]
     return f"{obj.__class__.__name__}({','.join(values)})"

--- a/centraldogma/util.py
+++ b/centraldogma/util.py
@@ -11,29 +11,13 @@
 #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #  License for the specific language governing permissions and limitations
 #  under the License.
-from __future__ import annotations
-
-from dataclasses import dataclass
 
 
-@dataclass
-class Revision:
-    """
-    A revision number of a ``Commit``.
-    """
+def to_string(obj, **fields) -> str:
+    items = vars(obj).items()
+    if not fields:
+        values = [f"{k}={v}" for k, v in items]
+    else:
+        values = [f"{k}={v}" for k, v in items if k in fields]
 
-    major: int
-
-    @staticmethod
-    def init() -> Revision:
-        """Revision ``1``, also known as 'INIT'."""
-        return _INIT
-
-    @staticmethod
-    def head() -> Revision:
-        """Revision ``-1``, also known as 'HEAD'."""
-        return _HEAD
-
-
-_INIT = Revision(1)
-_HEAD = Revision(-1)
+    return f"{obj.__class__.__name__}({','.join(values)})"

--- a/centraldogma/watcher.py
+++ b/centraldogma/watcher.py
@@ -1,0 +1,59 @@
+#  Copyright 2021 LINE Corporation
+#
+#  LINE Corporation licenses this file to you under the Apache License,
+#  version 2.0 (the "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+from asyncio import Future
+from dataclasses import dataclass
+from typing import TypeVar, Generic, Callable
+
+from centraldogma.data.revision import Revision
+
+T = TypeVar("T")
+
+
+@dataclass
+class Latest(Generic[T]):
+    """
+    An immutable holder of the latest known value and its `Revision` retrieved by `Watcher`.
+    """
+
+    revision: Revision
+    value: T
+
+
+class Watcher(Generic[T]):
+    """
+    Watches the changes of a repository or a file.
+    """
+
+    def latest(self) -> Latest[T]:
+        """
+        Returns the latest `Revision` and value of `watch_file()` result.
+        """
+        pass
+
+    def initial_value_future(self) -> Future[Latest[T]]:
+        pass
+
+    def watch(self, listener: Callable[[Revision, T], None]) -> None:
+        """
+        Registers a listener that will be invoked when the value of the watched entry becomes
+        available or changes.
+        """
+        pass
+
+    def close(self) -> None:
+        """
+        Stops watching the file specified in the `Query` or the path pattern in the repository.
+        """
+        pass

--- a/centraldogma/watcher.py
+++ b/centraldogma/watcher.py
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations
 #  under the License.
 
-from asyncio import Future
+from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import TypeVar, Generic, Callable
 
@@ -24,7 +24,7 @@ T = TypeVar("T")
 @dataclass
 class Latest(Generic[T]):
     """
-    An immutable holder of the latest known value and its `Revision` retrieved by `Watcher`.
+    A holder of the latest known value and its `Revision` retrieved by `Watcher`.
     """
 
     revision: Revision
@@ -43,7 +43,16 @@ class Watcher(Generic[T]):
         pass
 
     def initial_value_future(self) -> Future[Latest[T]]:
+        """
+        Returns the `Future` which is completed when the initial value retrieval is done  successfully.
+        """
         pass
+
+    def await_initial_value(self) -> Latest[T]:
+        """
+        Waits for the initial value to be available.
+        """
+        return self.initial_value_future().result()
 
     def watch(self, listener: Callable[[Revision, T], None]) -> None:
         """

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,7 @@ testpaths =
     tests
 markers =
     integration: mark as integration tests (deselect with '-m "not integration"')
+
+log_format = %(asctime)s %(levelname)s %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
+log_cli=true

--- a/tests/integration/test_content_service.py
+++ b/tests/integration/test_content_service.py
@@ -25,8 +25,7 @@ from centraldogma.dogma import Change, ChangeType, Commit, Dogma
 from centraldogma.exceptions import BadRequestException, ConflictException
 from centraldogma.query import Query
 
-dogma = Dogma(base_url="http://127.0.0.1:18080")
-# dogma = Dogma()
+dogma = Dogma()
 project_name = "TestProject"
 repo_name = "TestRepository"
 
@@ -119,7 +118,9 @@ def test_watch_repository(run_around_test):
     ret = dogma.push(project_name, repo_name, commit, [upsert_json])
 
     start = datetime.now()
-    revision = dogma.watch_repository(project_name, repo_name, Revision(ret.revision), "/**", 2000)
+    revision = dogma.watch_repository(
+        project_name, repo_name, Revision(ret.revision), "/**", 2000
+    )
     end = datetime.now()
     assert not revision  # Not modified
     assert (end - start).seconds >= 1
@@ -127,7 +128,9 @@ def test_watch_repository(run_around_test):
     with ThreadPoolExecutor(max_workers=1) as e:
         e.submit(push_later)
     start = datetime.now()
-    revision = dogma.watch_repository(project_name, repo_name, Revision(ret.revision), "/**", 4000)
+    revision = dogma.watch_repository(
+        project_name, repo_name, Revision(ret.revision), "/**", 4000
+    )
     end = datetime.now()
     assert revision.major == ret.revision + 1
     assert (end - start).seconds < 3
@@ -140,8 +143,9 @@ def test_watch_file(run_around_test):
     ret = dogma.push(project_name, repo_name, commit, [upsert_json])
 
     start = datetime.now()
-    entry: Optional[Entry[Any]] = dogma.watch_file(project_name, repo_name, Revision(ret.revision),
-                                                   Query.json("/test.json"), 2000)
+    entry: Optional[Entry[Any]] = dogma.watch_file(
+        project_name, repo_name, Revision(ret.revision), Query.json("/test.json"), 2000
+    )
     end = datetime.now()
     assert not entry  # Not modified
     assert (end - start).seconds >= 1
@@ -149,7 +153,9 @@ def test_watch_file(run_around_test):
     with ThreadPoolExecutor(max_workers=1) as e:
         e.submit(push_later)
     start = datetime.now()
-    entry = dogma.watch_file(project_name, repo_name, Revision(ret.revision), Query.json("/test.json"), 4000)
+    entry = dogma.watch_file(
+        project_name, repo_name, Revision(ret.revision), Query.json("/test.json"), 4000
+    )
     end = datetime.now()
     assert entry.revision.major == ret.revision + 1
     assert entry.content == {"foo": "qux"}

--- a/tests/integration/test_content_service.py
+++ b/tests/integration/test_content_service.py
@@ -50,125 +50,130 @@ def run_around_test():
     reason="Integration tests are disabled. Use `INTEGRATION_TEST=true pytest` to enable them.",
 )
 @pytest.mark.integration
-def test_content(run_around_test):
-    files = dogma.list_files(project_name, repo_name)
-    assert len(files) == 0
+class TestContentService:
+    def test_content(self, run_around_test):
+        files = dogma.list_files(project_name, repo_name)
+        assert len(files) == 0
 
-    commit = Commit("Upsert test.json")
-    upsert_json = Change("/test .json", ChangeType.UPSERT_JSON, {"foo": "bar"})
-    with pytest.raises(BadRequestException):
+        commit = Commit("Upsert test.json")
+        upsert_json = Change("/test .json", ChangeType.UPSERT_JSON, {"foo": "bar"})
+        with pytest.raises(BadRequestException):
+            dogma.push(project_name, repo_name, commit, [upsert_json])
+        upsert_json = Change("/test.json", ChangeType.UPSERT_JSON, {"foo": "bar"})
+        ret = dogma.push(project_name, repo_name, commit, [upsert_json])
+        assert ret.revision == 2
+
+        with pytest.raises(RedundantChangeException):
+            dogma.push(project_name, repo_name, commit, [upsert_json])
+
+        commit = Commit("Upsert test.txt")
+        upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "foo")
+        ret = dogma.push(project_name, repo_name, commit, [upsert_text])
+        assert ret.revision == 3
+
+        commit = Commit("Upsert both json and txt")
+        upsert_json = Change("/test.json", ChangeType.UPSERT_JSON, {"foo": "bar2"})
+        upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "foo2")
+        ret = dogma.push(project_name, repo_name, commit, [upsert_json, upsert_text])
+        assert ret.revision == 4
+
+        commit = Commit("Rename the json")
+        rename_json = Change("/test2.json", ChangeType.RENAME, "/test3.json")
+        with pytest.raises(ChangeConflictException):
+            dogma.push(project_name, repo_name, commit, [rename_json])
+        rename_json = Change("/test.json", ChangeType.RENAME, "")
+
+        with pytest.raises(BadRequestException):
+            dogma.push(project_name, repo_name, commit, [rename_json])
+        rename_json = Change("/test.json", ChangeType.RENAME, "/test2.json")
+        ret = dogma.push(project_name, repo_name, commit, [rename_json])
+        assert ret.revision == 5
+
+        files = dogma.list_files(project_name, repo_name)
+        assert len(files) == 2
+        assert set(map(lambda x: x.path, files)) == {"/path", "/test2.json"}
+        assert set(map(lambda x: x.type, files)) == {"DIRECTORY", "JSON"}
+
+        commit = Commit("Remove the json")
+        remove_json = Change("/test.json", ChangeType.REMOVE)
+        with pytest.raises(ChangeConflictException):
+            dogma.push(project_name, repo_name, commit, [remove_json])
+        remove_json = Change("/test2.json", ChangeType.REMOVE)
+        ret = dogma.push(project_name, repo_name, commit, [remove_json])
+        assert ret.revision == 6
+
+        with pytest.raises(ChangeConflictException):
+            dogma.push(project_name, repo_name, commit, [remove_json])
+
+        files = dogma.list_files(project_name, repo_name)
+        assert len(files) == 1
+
+        commit = Commit("Remove the folder")
+        remove_folder = Change("/path", ChangeType.REMOVE)
+        ret = dogma.push(project_name, repo_name, commit, [remove_folder])
+        assert ret.revision == 7
+
+        files = dogma.list_files(project_name, repo_name)
+        assert len(files) == 0
+
+    def test_watch_repository(self, run_around_test):
+        commit = Commit("Upsert test.json")
+        upsert_json = Change("/test.json", ChangeType.UPSERT_JSON, {"foo": "bar"})
+        ret = dogma.push(project_name, repo_name, commit, [upsert_json])
+
+        start = datetime.now()
+        revision = dogma.watch_repository(
+            project_name, repo_name, Revision(ret.revision), "/**", 2000
+        )
+        end = datetime.now()
+        assert not revision  # Not modified
+        assert (end - start).seconds >= 1
+
+        with ThreadPoolExecutor(max_workers=1) as e:
+            e.submit(self.push_later)
+        start = datetime.now()
+        revision = dogma.watch_repository(
+            project_name, repo_name, Revision(ret.revision), "/**", 4000
+        )
+        end = datetime.now()
+        assert revision.major == ret.revision + 1
+        assert (end - start).seconds < 3
+
+    def test_watch_file(self, run_around_test):
+        commit = Commit("Upsert test.json")
+        upsert_json = Change("/test.json", ChangeType.UPSERT_JSON, {"foo": "bar"})
+        ret = dogma.push(project_name, repo_name, commit, [upsert_json])
+
+        start = datetime.now()
+        entry: Optional[Entry[Any]] = dogma.watch_file(
+            project_name,
+            repo_name,
+            Revision(ret.revision),
+            Query.json("/test.json"),
+            2000,
+        )
+        end = datetime.now()
+        assert not entry  # Not modified
+        assert (end - start).seconds >= 1
+
+        with ThreadPoolExecutor(max_workers=1) as e:
+            e.submit(self.push_later)
+        start = datetime.now()
+        entry = dogma.watch_file(
+            project_name,
+            repo_name,
+            Revision(ret.revision),
+            Query.json("/test.json"),
+            4000,
+        )
+        end = datetime.now()
+        assert entry.revision.major == ret.revision + 1
+        assert entry.content == {"foo": "qux"}
+        assert (end - start).seconds < 3
+
+    @staticmethod
+    def push_later():
+        time.sleep(1)
+        commit = Commit("Upsert test.json")
+        upsert_json = Change("/test.json", ChangeType.UPSERT_JSON, {"foo": "qux"})
         dogma.push(project_name, repo_name, commit, [upsert_json])
-    upsert_json = Change("/test.json", ChangeType.UPSERT_JSON, {"foo": "bar"})
-    ret = dogma.push(project_name, repo_name, commit, [upsert_json])
-    assert ret.revision == 2
-
-    with pytest.raises(RedundantChangeException):
-        dogma.push(project_name, repo_name, commit, [upsert_json])
-
-    commit = Commit("Upsert test.txt")
-    upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "foo")
-    ret = dogma.push(project_name, repo_name, commit, [upsert_text])
-    assert ret.revision == 3
-
-    commit = Commit("Upsert both json and txt")
-    upsert_json = Change("/test.json", ChangeType.UPSERT_JSON, {"foo": "bar2"})
-    upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "foo2")
-    ret = dogma.push(project_name, repo_name, commit, [upsert_json, upsert_text])
-    assert ret.revision == 4
-
-    commit = Commit("Rename the json")
-    rename_json = Change("/test2.json", ChangeType.RENAME, "/test3.json")
-    with pytest.raises(ChangeConflictException):
-        dogma.push(project_name, repo_name, commit, [rename_json])
-    rename_json = Change("/test.json", ChangeType.RENAME, "")
-
-    with pytest.raises(BadRequestException):
-        dogma.push(project_name, repo_name, commit, [rename_json])
-    rename_json = Change("/test.json", ChangeType.RENAME, "/test2.json")
-    ret = dogma.push(project_name, repo_name, commit, [rename_json])
-    assert ret.revision == 5
-
-    files = dogma.list_files(project_name, repo_name)
-    assert len(files) == 2
-    assert set(map(lambda x: x.path, files)) == {"/path", "/test2.json"}
-    assert set(map(lambda x: x.type, files)) == {"DIRECTORY", "JSON"}
-
-    commit = Commit("Remove the json")
-    remove_json = Change("/test.json", ChangeType.REMOVE)
-    with pytest.raises(ChangeConflictException):
-        dogma.push(project_name, repo_name, commit, [remove_json])
-    remove_json = Change("/test2.json", ChangeType.REMOVE)
-    ret = dogma.push(project_name, repo_name, commit, [remove_json])
-    assert ret.revision == 6
-
-    with pytest.raises(ChangeConflictException):
-        dogma.push(project_name, repo_name, commit, [remove_json])
-
-    files = dogma.list_files(project_name, repo_name)
-    assert len(files) == 1
-
-    commit = Commit("Remove the folder")
-    remove_folder = Change("/path", ChangeType.REMOVE)
-    ret = dogma.push(project_name, repo_name, commit, [remove_folder])
-    assert ret.revision == 7
-
-    files = dogma.list_files(project_name, repo_name)
-    assert len(files) == 0
-
-
-@pytest.mark.integration
-def test_watch_repository(run_around_test):
-    commit = Commit("Upsert test.json")
-    upsert_json = Change("/test.json", ChangeType.UPSERT_JSON, {"foo": "bar"})
-    ret = dogma.push(project_name, repo_name, commit, [upsert_json])
-
-    start = datetime.now()
-    revision = dogma.watch_repository(
-        project_name, repo_name, Revision(ret.revision), "/**", 2000
-    )
-    end = datetime.now()
-    assert not revision  # Not modified
-    assert (end - start).seconds >= 1
-
-    with ThreadPoolExecutor(max_workers=1) as e:
-        e.submit(push_later)
-    start = datetime.now()
-    revision = dogma.watch_repository(
-        project_name, repo_name, Revision(ret.revision), "/**", 4000
-    )
-    end = datetime.now()
-    assert revision.major == ret.revision + 1
-    assert (end - start).seconds < 3
-
-
-@pytest.mark.integration
-def test_watch_file(run_around_test):
-    commit = Commit("Upsert test.json")
-    upsert_json = Change("/test.json", ChangeType.UPSERT_JSON, {"foo": "bar"})
-    ret = dogma.push(project_name, repo_name, commit, [upsert_json])
-
-    start = datetime.now()
-    entry: Optional[Entry[Any]] = dogma.watch_file(
-        project_name, repo_name, Revision(ret.revision), Query.json("/test.json"), 2000
-    )
-    end = datetime.now()
-    assert not entry  # Not modified
-    assert (end - start).seconds >= 1
-
-    with ThreadPoolExecutor(max_workers=1) as e:
-        e.submit(push_later)
-    start = datetime.now()
-    entry = dogma.watch_file(
-        project_name, repo_name, Revision(ret.revision), Query.json("/test.json"), 4000
-    )
-    end = datetime.now()
-    assert entry.revision.major == ret.revision + 1
-    assert entry.content == {"foo": "qux"}
-    assert (end - start).seconds < 3
-
-
-def push_later():
-    time.sleep(1)
-    commit = Commit("Upsert test.json")
-    upsert_json = Change("/test.json", ChangeType.UPSERT_JSON, {"foo": "qux"})
-    ret = dogma.push(project_name, repo_name, commit, [upsert_json])

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -88,13 +88,12 @@ def test_file_watcher(run_around_test):
     upsert_text = Change("/test.json", ChangeType.UPSERT_JSON, {"a": 1, "b": 2, "c": 3})
     result = dogma.push(project_name, repo_name, commit, [upsert_text])
 
-    watcher: Watcher[str] = dogma.file_watcher(
+    with dogma.file_watcher(
         project_name,
         repo_name,
         Query.json_path("/test.json", ["$.a"]),
         lambda j: json.dumps(j),
-    )
-    with watcher:
+    ) as watcher:
         future: Future[Revision] = Future()
 
         def listener(revision1: Revision, _: str) -> None:

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -1,0 +1,146 @@
+#  Copyright 2021 LINE Corporation
+#
+#  LINE Corporation licenses this file to you under the Apache License,
+#  version 2.0 (the "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+import json
+import os
+from concurrent.futures import Future
+from concurrent.futures import TimeoutError
+from typing import Any
+
+import pytest
+
+from centraldogma.data import Commit, Change, ChangeType
+from centraldogma.data.revision import Revision
+from centraldogma.query import Query
+from centraldogma.watcher import Watcher
+from centraldogma.dogma import Dogma
+
+dogma = Dogma()
+project_name = "TestProject"
+repo_name = "TestRepository"
+
+
+@pytest.fixture(scope="module")
+def run_around_test():
+    try:
+        dogma.remove_project(project_name)
+    except:
+        print()
+    try:
+        dogma.purge_project(project_name)
+    except:
+        print()
+
+    dogma.create_project(project_name)
+    dogma.create_repository(project_name, repo_name)
+    yield
+    dogma.remove_repository(project_name, repo_name)
+    dogma.purge_repository(project_name, repo_name)
+    dogma.remove_project(project_name)
+    dogma.purge_project(project_name)
+
+
+@pytest.mark.skipif(
+    os.getenv("INTEGRATION_TEST", "false").lower() != "true",
+    reason="Integration tests are disabled. Use `INTEGRATION_TEST=true pytest` to enable them.",
+)
+@pytest.mark.integration
+def test_repository_watcher(run_around_test):
+    watcher: Watcher[Revision] = dogma.repository_watcher(
+        project_name, repo_name, "/**"
+    )
+    with watcher:
+        future: Future[Revision] = Future()
+
+        def listener(revision1: Revision, _: Revision) -> None:
+            future.set_result(revision1)
+
+        watcher.watch(listener)
+        commit = Commit("Upsert1 test.txt")
+        upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "foo")
+        result = dogma.push(project_name, repo_name, commit, [upsert_text])
+        watched_revision = future.result()
+        assert result.revision == watched_revision.major
+
+        future = Future()
+        commit = Commit("Upsert2 test.txt")
+        upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "bar")
+        result = dogma.push(project_name, repo_name, commit, [upsert_text])
+        watched_revision = future.result()
+        assert result.revision == watched_revision.major
+
+        future = Future()
+        commit = Commit("Upsert3 test.txt")
+        upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "qux")
+        result = dogma.push(project_name, repo_name, commit, [upsert_text])
+        watched_revision = future.result()
+        assert result.revision == watched_revision.major
+
+
+@pytest.mark.skipif(
+    os.getenv("INTEGRATION_TEST", "false").lower() != "true",
+    reason="Integration tests are disabled. Use `INTEGRATION_TEST=true pytest` to enable them.",
+)
+@pytest.mark.integration
+def test_file_watcher(run_around_test):
+
+    commit = Commit("Upsert1 test.json")
+    upsert_text = Change("/test.json", ChangeType.UPSERT_JSON, {"a": 1, "b": 2, "c": 3})
+    result = dogma.push(project_name, repo_name, commit, [upsert_text])
+
+    watcher: Watcher[str] = dogma.file_watcher(
+        project_name,
+        repo_name,
+        Query.json_path("/test.json", ["$.a"]),
+        lambda j: json.dumps(j),
+    )
+    with watcher:
+        future: Future[Revision] = Future()
+
+        def listener(revision1: Revision, _: str) -> None:
+            future.set_result(revision1)
+
+        watcher.watch(listener)
+        commit = Commit("Upsert1 test.json")
+        upsert_text = Change(
+            "/test.json", ChangeType.UPSERT_JSON, {"a": 1, "b": 12, "c": 3}
+        )
+        dogma.push(project_name, repo_name, commit, [upsert_text])
+
+        with pytest.raises(TimeoutError):
+            future.result(timeout=0.5)
+
+        upsert_text = Change(
+            "/test.json", ChangeType.UPSERT_JSON, {"a": 11, "b": 12, "c": 33}
+        )
+        result = dogma.push(project_name, repo_name, commit, [upsert_text])
+        watched_revision = future.result()
+        assert result.revision == watched_revision.major
+
+        future = Future()
+        commit = Commit("Upsert2 test.json")
+        upsert_text = Change(
+            "/test.json", ChangeType.UPSERT_JSON, {"a": 21, "b": 12, "c": 33}
+        )
+        result = dogma.push(project_name, repo_name, commit, [upsert_text])
+        watched_revision = future.result()
+        assert result.revision == watched_revision.major
+
+        future = Future()
+        commit = Commit("Upsert3 test.json")
+        upsert_text = Change(
+            "/test.json", ChangeType.UPSERT_JSON, {"a": 21, "b": 22, "c": 33}
+        )
+        dogma.push(project_name, repo_name, commit, [upsert_text])
+        with pytest.raises(TimeoutError):
+            future.result(timeout=0.5)

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -15,15 +15,14 @@ import json
 import os
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError
-from typing import Any
 
 import pytest
 
 from centraldogma.data import Commit, Change, ChangeType
 from centraldogma.data.revision import Revision
+from centraldogma.dogma import Dogma
 from centraldogma.query import Query
 from centraldogma.watcher import Watcher
-from centraldogma.dogma import Dogma
 
 dogma = Dogma()
 project_name = "TestProject"
@@ -32,15 +31,6 @@ repo_name = "TestRepository"
 
 @pytest.fixture(scope="module")
 def run_around_test():
-    try:
-        dogma.remove_project(project_name)
-    except:
-        print()
-    try:
-        dogma.purge_project(project_name)
-    except:
-        print()
-
     dogma.create_project(project_name)
     dogma.create_repository(project_name, repo_name)
     yield

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -102,7 +102,7 @@ def test_file_watcher(run_around_test):
         watcher.watch(listener)
         commit = Commit("Upsert1 test.json")
         upsert_text = Change(
-            "/test.json", ChangeType.UPSERT_JSON, {"a": 1, "b": 12, "c": 3}
+            "/test.json", ChangeType.UPSERT_JSON, {"b": 12, "c": 3}
         )
         dogma.push(project_name, repo_name, commit, [upsert_text])
 
@@ -139,7 +139,7 @@ def test_await_init_value(run_around_test):
     with dogma.file_watcher(
         project_name,
         repo_name,
-        Query.json("/test.json"),
+        Query.json("/foo.json"),
         lambda j: json.dumps(j),
     ) as watcher:
 
@@ -148,8 +148,8 @@ def test_await_init_value(run_around_test):
             future.result(timeout=1)
         assert not watcher.latest()
 
-        commit = Commit("Upsert test.json")
-        upsert_text = Change("/test.json", ChangeType.UPSERT_JSON, {"a": 1})
+        commit = Commit("Upsert foo.json")
+        upsert_text = Change("/foo.json", ChangeType.UPSERT_JSON, {"a": 1})
         dogma.push(project_name, repo_name, commit, [upsert_text])
         latest: Latest[str] = future.result()
         assert latest.value == '{"a": 1}'

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -45,110 +45,109 @@ def run_around_test():
     reason="Integration tests are disabled. Use `INTEGRATION_TEST=true pytest` to enable them.",
 )
 @pytest.mark.integration
-def test_repository_watcher(run_around_test):
-    watcher: Watcher[Revision] = dogma.repository_watcher(
-        project_name, repo_name, "/**"
-    )
-    with watcher:
-        future: Future[Revision] = Future()
+class TestWatcher:
+    def test_repository_watcher(self, run_around_test):
+        watcher: Watcher[Revision] = dogma.repository_watcher(
+            project_name, repo_name, "/**"
+        )
+        with watcher:
+            future: Future[Revision] = Future()
 
-        def listener(revision1: Revision, _: Revision) -> None:
-            future.set_result(revision1)
+            def listener(revision1: Revision, _: Revision) -> None:
+                future.set_result(revision1)
 
-        watcher.watch(listener)
-        commit = Commit("Upsert1 test.txt")
-        upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "foo")
-        result = dogma.push(project_name, repo_name, commit, [upsert_text])
-        watched_revision = future.result()
-        assert result.revision == watched_revision.major
+            watcher.watch(listener)
+            commit = Commit("Upsert1 test.txt")
+            upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "foo")
+            result = dogma.push(project_name, repo_name, commit, [upsert_text])
+            watched_revision = future.result()
+            assert result.revision == watched_revision.major
 
-        future = Future()
-        commit = Commit("Upsert2 test.txt")
-        upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "bar")
-        result = dogma.push(project_name, repo_name, commit, [upsert_text])
-        watched_revision = future.result()
-        assert result.revision == watched_revision.major
+            future = Future()
+            commit = Commit("Upsert2 test.txt")
+            upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "bar")
+            result = dogma.push(project_name, repo_name, commit, [upsert_text])
+            watched_revision = future.result()
+            assert result.revision == watched_revision.major
 
-        future = Future()
-        commit = Commit("Upsert3 test.txt")
-        upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "qux")
-        result = dogma.push(project_name, repo_name, commit, [upsert_text])
-        watched_revision = future.result()
-        assert result.revision == watched_revision.major
+            future = Future()
+            commit = Commit("Upsert3 test.txt")
+            upsert_text = Change("/path/test.txt", ChangeType.UPSERT_TEXT, "qux")
+            result = dogma.push(project_name, repo_name, commit, [upsert_text])
+            watched_revision = future.result()
+            assert result.revision == watched_revision.major
 
+    def test_file_watcher(self, run_around_test):
 
-@pytest.mark.skipif(
-    os.getenv("INTEGRATION_TEST", "false").lower() != "true",
-    reason="Integration tests are disabled. Use `INTEGRATION_TEST=true pytest` to enable them.",
-)
-@pytest.mark.integration
-def test_file_watcher(run_around_test):
-
-    commit = Commit("Upsert1 test.json")
-    upsert_text = Change("/test.json", ChangeType.UPSERT_JSON, {"a": 1, "b": 2, "c": 3})
-    result = dogma.push(project_name, repo_name, commit, [upsert_text])
-
-    with dogma.file_watcher(
-        project_name,
-        repo_name,
-        Query.json_path("/test.json", ["$.a"]),
-        lambda j: json.dumps(j),
-    ) as watcher:
-        future: Future[Revision] = Future()
-
-        def listener(revision1: Revision, _: str) -> None:
-            future.set_result(revision1)
-
-        watcher.watch(listener)
         commit = Commit("Upsert1 test.json")
-        upsert_text = Change("/test.json", ChangeType.UPSERT_JSON, {"b": 12, "c": 3})
-        dogma.push(project_name, repo_name, commit, [upsert_text])
-
-        with pytest.raises(TimeoutError):
-            future.result(timeout=1)
-
         upsert_text = Change(
-            "/test.json", ChangeType.UPSERT_JSON, {"a": 11, "b": 12, "c": 33}
-        )
-        result = dogma.push(project_name, repo_name, commit, [upsert_text])
-        watched_revision = future.result()
-        assert result.revision == watched_revision.major
-
-        future = Future()
-        commit = Commit("Upsert2 test.json")
-        upsert_text = Change(
-            "/test.json", ChangeType.UPSERT_JSON, {"a": 21, "b": 12, "c": 33}
-        )
-        result = dogma.push(project_name, repo_name, commit, [upsert_text])
-        watched_revision = future.result()
-        assert result.revision == watched_revision.major
-
-        future = Future()
-        commit = Commit("Upsert3 test.json")
-        upsert_text = Change(
-            "/test.json", ChangeType.UPSERT_JSON, {"a": 21, "b": 22, "c": 33}
+            "/test.json", ChangeType.UPSERT_JSON, {"a": 1, "b": 2, "c": 3}
         )
         dogma.push(project_name, repo_name, commit, [upsert_text])
-        with pytest.raises(TimeoutError):
-            future.result(timeout=1)
 
+        with dogma.file_watcher(
+            project_name,
+            repo_name,
+            Query.json_path("/test.json", ["$.a"]),
+            lambda j: json.dumps(j),
+        ) as watcher:
+            future: Future[Revision] = Future()
 
-def test_await_init_value(run_around_test):
-    with dogma.file_watcher(
-        project_name,
-        repo_name,
-        Query.json("/foo.json"),
-        lambda j: json.dumps(j),
-    ) as watcher:
+            def listener(revision1: Revision, _: str) -> None:
+                future.set_result(revision1)
 
-        future: Future[Latest[str]] = watcher.initial_value_future()
-        with pytest.raises(TimeoutError):
-            future.result(timeout=1)
-        assert not watcher.latest()
+            watcher.watch(listener)
+            commit = Commit("Upsert1 test.json")
+            upsert_text = Change(
+                "/test.json", ChangeType.UPSERT_JSON, {"b": 12, "c": 3}
+            )
+            dogma.push(project_name, repo_name, commit, [upsert_text])
 
-        commit = Commit("Upsert foo.json")
-        upsert_text = Change("/foo.json", ChangeType.UPSERT_JSON, {"a": 1})
-        dogma.push(project_name, repo_name, commit, [upsert_text])
-        latest: Latest[str] = future.result()
-        assert latest.value == '{"a": 1}'
-        assert watcher.latest() == latest
+            with pytest.raises(TimeoutError):
+                future.result(timeout=1)
+
+            upsert_text = Change(
+                "/test.json", ChangeType.UPSERT_JSON, {"a": 11, "b": 12, "c": 33}
+            )
+            result = dogma.push(project_name, repo_name, commit, [upsert_text])
+            watched_revision = future.result()
+            assert result.revision == watched_revision.major
+
+            future = Future()
+            commit = Commit("Upsert2 test.json")
+            upsert_text = Change(
+                "/test.json", ChangeType.UPSERT_JSON, {"a": 21, "b": 12, "c": 33}
+            )
+            result = dogma.push(project_name, repo_name, commit, [upsert_text])
+            watched_revision = future.result()
+            assert result.revision == watched_revision.major
+
+            # As the content of 'a' has not been changed, the push event should not trigger 'listener'.
+            future = Future()
+            commit = Commit("Upsert3 test.json")
+            upsert_text = Change(
+                "/test.json", ChangeType.UPSERT_JSON, {"a": 21, "b": 22, "c": 33}
+            )
+            dogma.push(project_name, repo_name, commit, [upsert_text])
+            with pytest.raises(TimeoutError):
+                future.result(timeout=1)
+
+    def test_await_init_value(self, run_around_test):
+        with dogma.file_watcher(
+            project_name,
+            repo_name,
+            Query.json("/foo.json"),
+            lambda j: json.dumps(j),
+        ) as watcher:
+
+            future: Future[Latest[str]] = watcher.initial_value_future()
+            with pytest.raises(TimeoutError):
+                future.result(timeout=1)
+            assert not watcher.latest()
+
+            commit = Commit("Upsert foo.json")
+            upsert_text = Change("/foo.json", ChangeType.UPSERT_JSON, {"a": 1})
+            dogma.push(project_name, repo_name, commit, [upsert_text])
+            latest: Latest[str] = future.result()
+            assert latest.value == '{"a": 1}'
+            assert watcher.latest() == latest


### PR DESCRIPTION
Motivation:

The watch APIs implemented in upstream's client are the most loved features by users.
Python users also want to use the API in this Python client too.

Modifications:
- Implement `file_watcher` and `repository_watcher`
- Apply exception handler
- Update docstring

Result:

You can watch the changes in a repository using the watch APIs.
