### PR TITLE
Fix dict typing

### DIFF
--- a/centraldogma/base_client.py
+++ b/centraldogma/base_client.py
@@ -36,7 +36,7 @@ class BaseClient:
         self,
         method: str,
         path: str,
-        handler: Optional[dict[int, Callable[[Response], T]]] = None,
+        handler: Optional[Dict[int, Callable[[Response], T]]] = None,
         **kwargs,
     ) -> Union[Response, T]:
         kwargs = self._set_request_headers(method, **kwargs)

--- a/centraldogma/exceptions.py
+++ b/centraldogma/exceptions.py
@@ -13,7 +13,7 @@
 # under the License.
 from http import HTTPStatus
 from json import JSONDecodeError
-from typing import Callable
+from typing import Callable, Dict
 
 from httpx import Response
 
@@ -163,7 +163,7 @@ class InvalidResponseException(CentralDogmaException):
     pass
 
 
-_EXCEPTION_FACTORIES: dict[str, Callable[[str], CentralDogmaException]] = {
+_EXCEPTION_FACTORIES: Dict[str, Callable[[str], CentralDogmaException]] = {
     "com.linecorp.centraldogma.common." + exception.__name__: exception
     for exception in [
         ProjectExistsException,


### PR DESCRIPTION
Motivation
--
- In Python3.8+, `TypedDict` is supported by [PEP589](https://www.python.org/dev/peps/pep-0589/), but not compatible in some cases. It breaks our tests as follows.
```
tests/test_base_client.py:16: in <module>
    from centraldogma.exceptions import UnauthorizedException, NotFoundException
centraldogma/exceptions.py:166: in <module>
    _EXCEPTION_FACTORIES: dict[str, Callable[[str], CentralDogmaException]] = {
E   TypeError: 'type' object is not subscriptable

...

ERROR tests/test_base_client.py - TypeError: 'type' object is not subscriptable
ERROR tests/test_dogma.py - TypeError: 'type' object is not subscriptable
ERROR tests/test_exceptions.py - TypeError: 'type' object is not subscriptable
ERROR tests/integration/test_content_service.py - TypeError: 'type' object is not subscriptable
ERROR tests/integration/test_project_service.py - TypeError: 'type' object is not subscriptable
ERROR tests/integration/test_repository_service.py - TypeError: 'type' object is not subscriptable
```

Modifications
--
- Use `typing.Dict` instead of `dict` for typing.

Result
--
- `pytest` works as expected.