### PR TITLE
Activate sphinx for documentation

### DIFF
--- a/.github/workflows/central-dogma.yml
+++ b/.github/workflows/central-dogma.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
+          pre-build-command: "pip install sphinx_rtd_theme"
 
   linter:
     name: black --check

--- a/.github/workflows/central-dogma.yml
+++ b/.github/workflows/central-dogma.yml
@@ -10,6 +10,14 @@ on:
        - main
 
 jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "docs/"
+
   linter:
     name: black --check
     runs-on: ubuntu-latest

--- a/.github/workflows/central-dogma.yml
+++ b/.github/workflows/central-dogma.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-          pre-build-command: "pip install sphinx_rtd_theme"
+          pre-build-command: "python -m pip install --upgrade pip && pip install sphinx_rtd_theme dataclasses-json httpx[http2]"
 
   linter:
     name: black --check

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+public/
 
 # PyBuilder
 target/

--- a/README.md
+++ b/README.md
@@ -49,3 +49,9 @@ $ black .
 
 ### Documentation
 - [PEP 257](https://www.python.org/dev/peps/pep-0257)
+
+#### To build sphinx at local
+```
+$ pip install sphinx sphinx_rtd_theme
+$ cd docs && make html
+```

--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -111,13 +111,13 @@ class Dogma:
     ) -> List[Content]:
         """Lists files. The user should have read permission at least.
 
-        :param path_pattern: A path pattern is a variant of glob as follows.
-            "/**" - find all files recursively
-            "*.json" - find all JSON files recursively
-            "/foo/*.json" - find all JSON files under the directory /foo
-            "/*/foo.txt" - find all files named foo.txt at the second depth level
-            "*.json,/bar/*.txt" - use comma to match any patterns
-            This will bring all of the files in the repository, if unspecified.
+        :param path_pattern: A path pattern is a variant of glob as follows. |br|
+            "/\*\*" - find all files recursively |br|
+            "\*.json" - find all JSON files recursively |br|
+            "/foo/\*.json" - find all JSON files under the directory /foo |br|
+            "/\*/foo.txt" - find all files named foo.txt at the second depth level |br|
+            "\*.json,/bar/\*.txt" - use comma to match any patterns |br|
+            This will bring all of the files in the repository, if unspecified. |br|
         :param revision: The revision of the list to get. If not specified, gets the list of
             the latest revision.
         """
@@ -135,12 +135,12 @@ class Dogma:
         """Gets files. The user should have read permission at least. The difference from
             the API List files is that this includes the content of the files.
 
-        :param path_pattern: A path pattern is a variant of glob as follows.
-            "/**" - find all files recursively
-            "*.json" - find all JSON files recursively
-            "/foo/*.json" - find all JSON files under the directory /foo
-            "/*/foo.txt" - find all files named foo.txt at the second depth level
-            "*.json,/bar/*.txt" - use comma to match any patterns
+        :param path_pattern: A path pattern is a variant of glob as follows. |br|
+            "/\*\*" - find all files recursively |br|
+            "\*.json" - find all JSON files recursively |br|
+            "/foo/\*.json" - find all JSON files under the directory /foo |br|
+            "/\*/foo.txt" - find all files named foo.txt at the second depth level |br|
+            "\*.json,/bar/\*.txt" - use comma to match any patterns
             This will bring all of the files in the repository, if unspecified.
         :param revision: The revision of the list to get. If not specified, gets the list of
             the latest revision.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/centraldogma.data.rst
+++ b/docs/centraldogma.data.rst
@@ -1,0 +1,77 @@
+centraldogma.data package
+=========================
+
+Submodules
+----------
+
+centraldogma.data.change module
+-------------------------------
+
+.. automodule:: centraldogma.data.change
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.data.commit module
+-------------------------------
+
+.. automodule:: centraldogma.data.commit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.data.constants module
+----------------------------------
+
+.. automodule:: centraldogma.data.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.data.content module
+--------------------------------
+
+.. automodule:: centraldogma.data.content
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.data.creator module
+--------------------------------
+
+.. automodule:: centraldogma.data.creator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.data.project module
+--------------------------------
+
+.. automodule:: centraldogma.data.project
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.data.push\_result module
+-------------------------------------
+
+.. automodule:: centraldogma.data.push_result
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.data.repository module
+-----------------------------------
+
+.. automodule:: centraldogma.data.repository
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: centraldogma.data
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/centraldogma.rst
+++ b/docs/centraldogma.rst
@@ -1,0 +1,73 @@
+centraldogma package
+====================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   centraldogma.data
+
+Submodules
+----------
+
+centraldogma.base\_client module
+--------------------------------
+
+.. automodule:: centraldogma.base_client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.content\_service module
+------------------------------------
+
+.. automodule:: centraldogma.content_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.dogma module
+-------------------------
+
+.. automodule:: centraldogma.dogma
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.exceptions module
+------------------------------
+
+.. automodule:: centraldogma.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.project\_service module
+------------------------------------
+
+.. automodule:: centraldogma.project_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.repository\_service module
+---------------------------------------
+
+.. automodule:: centraldogma.repository_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: centraldogma
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. |br| raw:: html
+
+      <br>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(".."))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "centraldogma-python"
+copyright = "2022, hexoul, ikhoon, minwoox"
+author = "hexoul, ikhoon, minwoox"
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx_rtd_theme",
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. centraldogma-python documentation master file, created by
+   sphinx-quickstart on Fri Jan  7 16:27:06 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to centraldogma-python's documentation!
+===============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+centraldogma
+============
+
+.. toctree::
+   :maxdepth: 4
+
+   centraldogma


### PR DESCRIPTION
Motivation
--
- There is no `/docs` for documentation

Modifications
--
- Implement `*.rst` with `sphinx-quickstart` and `sphinx-apidoc`.
- There are inline delimiter characters including asterisk `*`. To make it literal, we have to escape as [reStructuredText](http://azuwis.github.io/sphinx_demo/quickref.html).

Result
--
- <img width="1123" alt="스크린샷 2022-01-07 오후 5 03 20" src="https://user-images.githubusercontent.com/11401808/148513744-9dd49d72-108e-4e03-a550-bd2ff8fd5bc2.png">
- <img width="1143" alt="스크린샷 2022-01-07 오후 5 03 12" src="https://user-images.githubusercontent.com/11401808/148513772-ceb81904-1543-4f13-aa57-e1e8cfbc88a3.png">

