### PR TITLE
Use `pydantic.dataclasses.dataclass` instead of `dataclasses.dataclass`

### DIFF
--- a/centraldogma/data/change.py
+++ b/centraldogma/data/change.py
@@ -11,11 +11,11 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Any
 
 from dataclasses_json import dataclass_json
+from pydantic.dataclasses import dataclass
 
 
 class ChangeType(Enum):

--- a/centraldogma/data/commit.py
+++ b/centraldogma/data/commit.py
@@ -11,10 +11,10 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from dataclasses import dataclass
 from typing import Optional
 
 from dataclasses_json import dataclass_json
+from pydantic.dataclasses import dataclass
 
 
 @dataclass_json

--- a/centraldogma/data/content.py
+++ b/centraldogma/data/content.py
@@ -11,10 +11,10 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from dataclasses import dataclass
 from typing import Any, Optional
 
 from dataclasses_json import dataclass_json
+from pydantic.dataclasses import dataclass
 
 
 @dataclass_json

--- a/centraldogma/data/creator.py
+++ b/centraldogma/data/creator.py
@@ -11,9 +11,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from dataclasses import dataclass
-
 from dataclasses_json import dataclass_json
+from pydantic.dataclasses import dataclass
 
 
 @dataclass_json

--- a/centraldogma/data/project.py
+++ b/centraldogma/data/project.py
@@ -11,15 +11,15 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from dataclasses import dataclass, field
+from dataclasses import field
 from datetime import datetime
 from typing import Optional
 
 from dataclasses_json import LetterCase, config, dataclass_json
 from dateutil import parser
 from marshmallow import fields
+from pydantic.dataclasses import dataclass
 
-from centraldogma.data.constants import DATE_FORMAT_ISO8601
 from centraldogma.data.creator import Creator
 
 

--- a/centraldogma/data/push_result.py
+++ b/centraldogma/data/push_result.py
@@ -11,12 +11,13 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from dataclasses import dataclass, field
+from dataclasses import field
 from datetime import datetime
 
 from dataclasses_json import LetterCase, config, dataclass_json
 from marshmallow import fields
 from dateutil import parser
+from pydantic.dataclasses import dataclass
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)

--- a/centraldogma/data/repository.py
+++ b/centraldogma/data/repository.py
@@ -11,13 +11,14 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from dataclasses import dataclass, field
+from dataclasses import field
 from datetime import datetime
 from typing import Optional
 
 from dataclasses_json import LetterCase, config, dataclass_json
 from dateutil import parser
 from marshmallow import fields
+from pydantic.dataclasses import dataclass
 
 from centraldogma.data.creator import Creator
 

--- a/centraldogma/data/revision.py
+++ b/centraldogma/data/revision.py
@@ -13,7 +13,7 @@
 #  under the License.
 from __future__ import annotations
 
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 
 
 @dataclass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.9"
 services:
   centraldogma:
-    image: line/centraldogma:0.54.0
+    image: line/centraldogma:latest
     ports:
       - "36462:36462"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.9"
 services:
   centraldogma:
-    image: line/centraldogma:latest
+    image: line/centraldogma:0.54.0
     ports:
       - "36462:36462"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 dataclasses-json
 httpx[http2]
 marshmallow
+pydantic
 python-dateutil
 
 # Dev dependencies


### PR DESCRIPTION
Motivation
--
- `dataclasses.dataclass` supports typing, but do not validate.
- `pydantic.dataclasses.dataclass` is a drop-in replacement for `dataclasses.dataclass` with **validation**.

References
--
- https://pydantic-docs.helpmanual.io/usage/dataclasses/
- https://pydantic-docs.helpmanual.io/