### PR TITLE
Implement merge files

### DIFF
--- a/centraldogma/content_service.py
+++ b/centraldogma/content_service.py
@@ -171,7 +171,11 @@ class ContentService:
         if revision:
             queries.append(f"revision={revision}")
         for merge_source in merge_sources:
-            query = f"optional_path={merge_source.path}" if merge_source.optional else f"path={merge_source.path}"
+            query = (
+                f"optional_path={merge_source.path}"
+                if merge_source.optional
+                else f"path={merge_source.path}"
+            )
             queries.append(query)
         for json_path in json_paths:
             queries.append(f"jsonpath={json_path}")

--- a/centraldogma/data/merge_source.py
+++ b/centraldogma/data/merge_source.py
@@ -1,0 +1,20 @@
+#  Copyright 2022 LINE Corporation
+#
+#  LINE Corporation licenses this file to you under the Apache License,
+#  version 2.0 (the "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License
+from pydantic.dataclasses import dataclass
+
+
+@dataclass
+class MergeSource:
+    path: str
+    optional: bool

--- a/centraldogma/data/merge_source.py
+++ b/centraldogma/data/merge_source.py
@@ -17,4 +17,4 @@ from pydantic.dataclasses import dataclass
 @dataclass
 class MergeSource:
     path: str
-    optional: bool
+    optional: bool = True

--- a/centraldogma/data/merged_entry.py
+++ b/centraldogma/data/merged_entry.py
@@ -31,12 +31,9 @@ class MergedEntry(Generic[T]):
         revision = Revision(json["revision"])
         entry_type = EntryType[json["type"]]
         content = json["content"]
-        # TODO: validate that entry_type matches content
         return MergedEntry(revision, paths, entry_type, content)
 
-    def __init__(
-        self, revision: Revision, paths: List[str], entry_type: EntryType, content: T
-    ):
+    def __init__(self, revision: Revision, paths: List[str], entry_type: EntryType, content: T):
         self.revision = revision
         self.paths = paths
         self.entry_type = entry_type

--- a/centraldogma/data/merged_entry.py
+++ b/centraldogma/data/merged_entry.py
@@ -22,7 +22,6 @@ T = TypeVar("T")
 
 
 class MergedEntry(Generic[T]):
-
     @staticmethod
     def from_dict(json: Any):
         paths: List[str] = json["paths"]
@@ -33,7 +32,9 @@ class MergedEntry(Generic[T]):
         content = json["content"]
         return MergedEntry(revision, paths, entry_type, content)
 
-    def __init__(self, revision: Revision, paths: List[str], entry_type: EntryType, content: T):
+    def __init__(
+        self, revision: Revision, paths: List[str], entry_type: EntryType, content: T
+    ):
         self.revision = revision
         self.paths = paths
         self.entry_type = entry_type

--- a/centraldogma/data/merged_entry.py
+++ b/centraldogma/data/merged_entry.py
@@ -11,29 +11,27 @@
 #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #  License for the specific language governing permissions and limitations
 #  under the License.
-from typing import Generic, TypeVar, List, Any
+from typing import List, Union
+
+from dataclasses_json.core import Json
 
 from centraldogma import util
 from centraldogma.data.entry import EntryType
 from centraldogma.data.revision import Revision
-from centraldogma.exceptions import CentralDogmaException, EntryNoContentException
-
-T = TypeVar("T")
+from centraldogma.exceptions import EntryNoContentException
 
 
-class MergedEntry(Generic[T]):
+class MergedEntry:
     @staticmethod
-    def from_dict(json: Any):
+    def from_dict(json: Json):
         paths: List[str] = json["paths"]
-        if len(paths) == 0:
-            raise CentralDogmaException(f"paths is unexpectedly empty for json: {json}")
         revision = Revision(json["revision"])
         entry_type = EntryType[json["type"]]
         content = json["content"]
         return MergedEntry(revision, paths, entry_type, content)
 
     def __init__(
-        self, revision: Revision, paths: List[str], entry_type: EntryType, content: T
+        self, revision: Revision, paths: List[str], entry_type: EntryType, content: Json
     ):
         self.revision = revision
         self.paths = paths
@@ -41,11 +39,10 @@ class MergedEntry(Generic[T]):
         self._content = content
 
     @property
-    def content(self) -> T:
-        """
-        Returns the content.
+    def content(self) -> Union[str, dict]:
+        """Returns the content.
 
-        :exception EntryNoContentException if the content is ``None``
+        :raises EntryNoContentException: it occurs if the content is ``None``
         """
         if not self._content:
             raise EntryNoContentException(

--- a/centraldogma/data/merged_entry.py
+++ b/centraldogma/data/merged_entry.py
@@ -1,0 +1,60 @@
+#  Copyright 2022 LINE Corporation
+#
+#  LINE Corporation licenses this file to you under the Apache License,
+#  version 2.0 (the "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+from typing import Generic, TypeVar, List, Any
+
+from centraldogma import util
+from centraldogma.data.entry import EntryType
+from centraldogma.data.revision import Revision
+from centraldogma.exceptions import CentralDogmaException, EntryNoContentException
+
+T = TypeVar("T")
+
+
+class MergedEntry(Generic[T]):
+
+    @staticmethod
+    def from_dict(json: Any):
+        paths: List[str] = json["paths"]
+        if len(paths) == 0:
+            raise CentralDogmaException(f"paths is unexpectedly empty for json: {json}")
+        revision = Revision(json["revision"])
+        entry_type = EntryType[json["type"]]
+        content = json["content"]
+        # TODO: validate that entry_type matches content
+        return MergedEntry(revision, paths, entry_type, content)
+
+    def __init__(
+        self, revision: Revision, paths: List[str], entry_type: EntryType, content: T
+    ):
+        self.revision = revision
+        self.paths = paths
+        self.entry_type = entry_type
+        self._content = content
+
+    @property
+    def content(self) -> T:
+        """
+        Returns the content.
+
+        :exception EntryNoContentException if the content is ``None``
+        """
+        if not self._content:
+            raise EntryNoContentException(
+                f"{self.paths} (type: {self.entry_type}, revision: {self.revision.major})"
+            )
+
+        return self._content
+
+    def __str__(self) -> str:
+        return util.to_string(self)

--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -16,6 +16,7 @@ from typing import List, Optional, TypeVar, Callable
 
 from centraldogma.base_client import BaseClient
 from centraldogma.content_service import ContentService
+
 # noinspection PyUnresolvedReferences
 from centraldogma.data import (
     Change,
@@ -332,4 +333,6 @@ class Dogma:
         """
         if json_paths is None:
             json_paths = []
-        return self.content_service.merge_files(project_name, repo_name, merge_sources, json_paths, revision)
+        return self.content_service.merge_files(
+            project_name, repo_name, merge_sources, json_paths, revision
+        )

--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -320,9 +320,9 @@ class Dogma:
         project_name: str,
         repo_name: str,
         merge_sources: List[MergeSource],
-        json_paths: List[str] = None,
+        json_paths: Optional[List[str]] = None,
         revision: Optional[int] = None,
-    ) -> MergedEntry[T]:
+    ) -> MergedEntry:
         """
         Returns the merged result of files represented by ``MergeSource``. Each ``MergeSource``
         can be optional, indicating that no error should be thrown even if the path doesn't exist.
@@ -331,8 +331,6 @@ class Dogma:
 
         :return: the ``MergedEntry`` which contains the merged content for the given query.
         """
-        if json_paths is None:
-            json_paths = []
         return self.content_service.merge_files(
-            project_name, repo_name, merge_sources, json_paths, revision
+            project_name, repo_name, merge_sources, json_paths or [], revision
         )

--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -319,9 +319,17 @@ class Dogma:
         project_name: str,
         repo_name: str,
         merge_sources: List[MergeSource],
-        json_paths=None,
+        json_paths: List[str] = None,
         revision: Optional[int] = None,
     ) -> MergedEntry[T]:
+        """
+        Returns the merged result of files represented by ``MergeSource``. Each ``MergeSource``
+        can be optional, indicating that no error should be thrown even if the path doesn't exist.
+        If ``json_paths`` is specified, each ``json_path`` is applied recursively on the merged
+        result. If any of the ``json_path``s is invalid, a ``QueryExecutionException`` is thrown.
+
+        :return: the ``MergedEntry`` which contains the merged content for the given query.
+        """
         if json_paths is None:
             json_paths = []
         return self.content_service.merge_files(project_name, repo_name, merge_sources, json_paths, revision)

--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -323,8 +323,7 @@ class Dogma:
         json_paths: Optional[List[str]] = None,
         revision: Optional[int] = None,
     ) -> MergedEntry:
-        """
-        Returns the merged result of files represented by ``MergeSource``. Each ``MergeSource``
+        """Returns the merged result of files represented by ``MergeSource``. Each ``MergeSource``
         can be optional, indicating that no error should be thrown even if the path doesn't exist.
         If ``json_paths`` is specified, each ``json_path`` is applied recursively on the merged
         result. If any of the ``json_path``s is invalid, a ``QueryExecutionException`` is thrown.

--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -328,6 +328,7 @@ class Dogma:
         If ``json_paths`` is specified, each ``json_path`` is applied recursively on the merged
         result. If any of the ``json_path``s is invalid, a ``QueryExecutionException`` is thrown.
 
+        :raises ValueError: If the provided ``merge_sources`` is empty.
         :return: the ``MergedEntry`` which contains the merged content for the given query.
         """
         return self.content_service.merge_files(

--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -16,7 +16,6 @@ from typing import List, Optional, TypeVar, Callable
 
 from centraldogma.base_client import BaseClient
 from centraldogma.content_service import ContentService
-
 # noinspection PyUnresolvedReferences
 from centraldogma.data import (
     Change,
@@ -28,6 +27,8 @@ from centraldogma.data import (
     Repository,
 )
 from centraldogma.data.entry import Entry
+from centraldogma.data.merge_source import MergeSource
+from centraldogma.data.merged_entry import MergedEntry
 from centraldogma.data.revision import Revision
 from centraldogma.project_service import ProjectService
 from centraldogma.query import Query
@@ -312,3 +313,15 @@ class Dogma:
         )
         watcher.start()
         return watcher
+
+    def merge_files(
+        self,
+        project_name: str,
+        repo_name: str,
+        merge_sources: List[MergeSource],
+        json_paths=None,
+        revision: Optional[int] = None,
+    ) -> MergedEntry[T]:
+        if json_paths is None:
+            json_paths = []
+        return self.content_service.merge_files(project_name, repo_name, merge_sources, json_paths, revision)

--- a/tests/integration/test_content_service.py
+++ b/tests/integration/test_content_service.py
@@ -199,18 +199,15 @@ class TestContentService:
     def test_merge_files(self, run_around_test):
         commit = Commit("Upsert test.json")
         upsert_json = Change("/test.json", ChangeType.UPSERT_JSON, {"foo": "bar"})
-        ret = dogma.push(project_name, repo_name, commit, [upsert_json])
-        assert ret.revision == 2
+        dogma.push(project_name, repo_name, commit, [upsert_json])
         upsert_json = Change("/test2.json", ChangeType.UPSERT_JSON, {"foo2": "bar2"})
-        ret = dogma.push(project_name, repo_name, commit, [upsert_json])
-        assert ret.revision == 3
+        dogma.push(project_name, repo_name, commit, [upsert_json])
         upsert_json = Change(
             "/test3.json",
             ChangeType.UPSERT_JSON,
             {"inner": {"inner2": {"foo3": "bar3"}}},
         )
-        ret = dogma.push(project_name, repo_name, commit, [upsert_json])
-        assert ret.revision == 4
+        dogma.push(project_name, repo_name, commit, [upsert_json])
 
         merge_sources = [
             MergeSource("/nonexisting.json", False),

--- a/tests/integration/test_content_service.py
+++ b/tests/integration/test_content_service.py
@@ -28,7 +28,8 @@ from centraldogma.exceptions import (
     RedundantChangeException,
     ChangeConflictException,
     CentralDogmaException,
-    EntryNotFoundException, QueryExecutionException,
+    EntryNotFoundException,
+    QueryExecutionException,
 )
 from centraldogma.query import Query
 
@@ -203,7 +204,11 @@ class TestContentService:
         upsert_json = Change("/test2.json", ChangeType.UPSERT_JSON, {"foo2": "bar2"})
         ret = dogma.push(project_name, repo_name, commit, [upsert_json])
         assert ret.revision == 3
-        upsert_json = Change("/test3.json", ChangeType.UPSERT_JSON, {"inner": {"inner2": {"foo3": "bar3"}}})
+        upsert_json = Change(
+            "/test3.json",
+            ChangeType.UPSERT_JSON,
+            {"inner": {"inner2": {"foo3": "bar3"}}},
+        )
         ret = dogma.push(project_name, repo_name, commit, [upsert_json])
         assert ret.revision == 4
 
@@ -220,7 +225,11 @@ class TestContentService:
         ]
         ret = dogma.merge_files(project_name, repo_name, merge_sources)
         assert ret.entry_type == EntryType.JSON
-        assert ret.content == {"foo": "bar", "foo2": "bar2", "inner": {"inner2": {"foo3": "bar3"}}}
+        assert ret.content == {
+            "foo": "bar",
+            "foo2": "bar2",
+            "inner": {"inner2": {"foo3": "bar3"}},
+        }
 
         with pytest.raises(QueryExecutionException):
             dogma.merge_files(project_name, repo_name, merge_sources, ["$.inner2"])
@@ -229,7 +238,9 @@ class TestContentService:
         assert ret.entry_type == EntryType.JSON
         assert ret.content == {"inner2": {"foo3": "bar3"}}
 
-        ret = dogma.merge_files(project_name, repo_name, merge_sources, ["$.inner", "$.inner2"])
+        ret = dogma.merge_files(
+            project_name, repo_name, merge_sources, ["$.inner", "$.inner2"]
+        )
         assert ret.entry_type == EntryType.JSON
         assert ret.content == {"foo3": "bar3"}
 

--- a/tests/test_dogma.py
+++ b/tests/test_dogma.py
@@ -11,6 +11,12 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from datetime import datetime
+from http import HTTPStatus
+
+import pytest
+from httpx import Response
+
 from centraldogma.data import (
     DATE_FORMAT_ISO8601,
     DATE_FORMAT_ISO8601_MS,
@@ -30,10 +36,6 @@ from centraldogma.exceptions import (
     ProjectExistsException,
     RepositoryExistsException,
 )
-from datetime import datetime
-from http import HTTPStatus
-from httpx import Response
-import pytest
 
 client = Dogma("http://baseurl", "token")
 
@@ -511,6 +513,11 @@ def test_merge(respx_mock):
     route = respx_mock.get(url).mock(
         return_value=Response(HTTPStatus.OK, json=mock_merge_result)
     )
+
+    # merge_sources cannot be empty
+    with pytest.raises(ValueError):
+        client.merge_files("myproject", "myrepo", [])
+
     merge_sources = [
         MergeSource("test.json"),
         MergeSource("test2.json"),

--- a/tests/test_dogma.py
+++ b/tests/test_dogma.py
@@ -72,7 +72,7 @@ mock_merge_result = {
     "revision": 4,
     "type": "JSON",
     "content": {"foo": "bar"},
-    "paths": ["/test.json", "/test2.json", "/test3.json"]
+    "paths": ["/test.json", "/test2.json", "/test3.json"],
 }
 
 


### PR DESCRIPTION
`CentralDogma` has a feature called `mergeFiles` which lets users "merge" files and retrieve the result easily.

https://github.com/line/centraldogma/blob/0c397eb1f5aa99cec586adcf5417464032ce117f/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java#L247-L269

It might be useful to implement this feature for the python client as well.