### PR TITLE
watcher keep alive even get 304 not modified

### DIFF
--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -248,7 +248,7 @@ class Dogma:
         repo_name: str,
         path_pattern: str,
         function: Callable[[Revision], T] = lambda x: x,
-        timeout_millis: int = _DEFAULT_WATCH_TIMEOUT_MILLIS
+        timeout_millis: int = _DEFAULT_WATCH_TIMEOUT_MILLIS,
     ) -> Watcher[T]:
         """
         Returns a ``Watcher`` which notifies its listeners when the specified repository has a new commit

--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -248,6 +248,7 @@ class Dogma:
         repo_name: str,
         path_pattern: str,
         function: Callable[[Revision], T] = lambda x: x,
+        timeout_millis: int = _DEFAULT_WATCH_TIMEOUT_MILLIS
     ) -> Watcher[T]:
         """
         Returns a ``Watcher`` which notifies its listeners when the specified repository has a new commit
@@ -267,6 +268,7 @@ class Dogma:
 
         :param path_pattern: the path pattern to match files in the repository.
         :param function: the function to convert the given `Revision` into another.
+        :param timeout_millis: the timeout millis for the watching request.
 
         .. _a known issue:
             https://github.com/line/centraldogma/issues/40
@@ -276,7 +278,7 @@ class Dogma:
             project_name,
             repo_name,
             path_pattern,
-            _DEFAULT_WATCH_TIMEOUT_MILLIS,
+            timeout_millis,
             function,
         )
         watcher.start()

--- a/centraldogma/repository_watcher.py
+++ b/centraldogma/repository_watcher.py
@@ -148,8 +148,8 @@ class AbstractWatcher(Watcher[T]):
                 self.notify_listeners()
                 if not old_latest:
                     self._initial_value_future.set_result(new_latest)
-                # Watch again for the next change.
-                return 0
+            # Watch again for the next change.
+            return 0
         except Exception as ex:
             if isinstance(ex, EntryNotFoundException):
                 logging.info(
@@ -174,7 +174,7 @@ class AbstractWatcher(Watcher[T]):
                     self.path_pattern,
                     ex,
                 )
-        return num_attempts_so_far + 1
+            return num_attempts_so_far + 1
 
     def _do_watch(self, last_known_revision: Revision) -> Optional[Latest[T]]:
         pass

--- a/centraldogma/repository_watcher.py
+++ b/centraldogma/repository_watcher.py
@@ -113,18 +113,19 @@ class AbstractWatcher(Watcher[T]):
             listener(self._latest.revision, self._latest.value)
 
     def _schedule_watch(self, num_attempts_so_far: int) -> None:
-        while num_attempts_so_far >= 0:
+        num_attempts = num_attempts_so_far
+        while num_attempts >= 0:
             if self._is_stopped():
                 break
 
-            if num_attempts_so_far == 0:
+            if num_attempts == 0:
                 delay = _DELAY_ON_SUCCESS_MILLIS if self._latest is None else 0
             else:
-                delay = self._next_delay_millis(num_attempts_so_far)
+                delay = self._next_delay_millis(num_attempts)
 
             # FIXME(ikhoon): Replace asyncio.sleep() after AsyncClient is implemented.
             time.sleep(delay / 1000)
-            num_attempts_so_far = self._watch(num_attempts_so_far)
+            num_attempts = self._watch(num_attempts)
         return None
 
     def _watch(self, num_attempts_so_far: int) -> int:
@@ -147,8 +148,8 @@ class AbstractWatcher(Watcher[T]):
                 self.notify_listeners()
                 if not old_latest:
                     self._initial_value_future.set_result(new_latest)
-            # Watch again for the next change.
-            return 0
+                # Watch again for the next change.
+                return 0
         except Exception as ex:
             if isinstance(ex, EntryNotFoundException):
                 logging.info(
@@ -173,7 +174,7 @@ class AbstractWatcher(Watcher[T]):
                     self.path_pattern,
                     ex,
                 )
-            return num_attempts_so_far + 1
+        return num_attempts_so_far + 1
 
     def _do_watch(self, last_known_revision: Revision) -> Optional[Latest[T]]:
         pass

--- a/centraldogma/repository_watcher.py
+++ b/centraldogma/repository_watcher.py
@@ -146,9 +146,8 @@ class AbstractWatcher(Watcher[T]):
                 self.notify_listeners()
                 if not old_latest:
                     self._initial_value_future.set_result(new_latest)
-
-                # Watch again for the next change.
-                self._schedule_watch(0)
+            # Watch again for the next change.
+            self._schedule_watch(0)
         except Exception as ex:
             if isinstance(ex, EntryNotFoundException):
                 logging.info(

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ black
 codecov
 pytest
 pytest-cov
+pytest-mock
 respx
 setuptools

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -220,7 +220,7 @@ class TestWatcher:
             project_name, repo_name, "/**", timeout_millis=timeout_millis
         )
 
-        # wait until watcher get NOT_MODIFIED at least once.
+        # wait until watcher get `NOT_MODIFIED` at least once.
         time.sleep(4 * timeout_second)
 
         commit = Commit("Upsert modify.txt")

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -210,8 +210,7 @@ class TestWatcher:
             assert watcher.latest() == latest
 
     def test_not_modified_repository_watcher(self, run_around_test):
-        """It verifies that a watcher keep watching well even after `NOT_MODIFIED`.
-        """
+        """It verifies that a watcher keep watching well even after `NOT_MODIFIED`."""
         timeout_millis = 1000
         timeout_second = timeout_millis / 1000
 

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -218,7 +218,8 @@ class TestWatcher:
 
         # pass short timeout millis for testing purpose.
         watcher: Watcher[Revision] = dogma.repository_watcher(
-            project_name, repo_name, "/**", timeout_millis=timeout_millis)
+            project_name, repo_name, "/**", timeout_millis=timeout_millis
+        )
 
         # wait until watcher get NOT_MODIFIED at least once.
         time.sleep(5 * timeout_second)

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -222,14 +222,13 @@ class TestWatcher:
         )
 
         # wait until watcher get NOT_MODIFIED at least once.
-        time.sleep(5 * timeout_second)
+        time.sleep(4 * timeout_second)
 
         commit = Commit("Upsert modify.txt")
         upsert_text = Change("/path/modify.txt", ChangeType.UPSERT_TEXT, "modified")
         result = dogma.push(project_name, repo_name, commit, [upsert_text])
 
         # wait until watcher watch latest.
-        while watcher.latest() is None:
-            time.sleep(timeout_second)
+        time.sleep(4 * timeout_second)
 
         assert result.revision == watcher.latest().revision.major

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -13,6 +13,7 @@
 #  under the License.
 import json
 import os
+import time
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError
 
@@ -207,3 +208,27 @@ class TestWatcher:
             latest: Latest[str] = future.result()
             assert latest.value == '{"a": 1}'
             assert watcher.latest() == latest
+
+    def test_not_modified_repository_watcher(self, run_around_test):
+        """
+        It is for checking the watcher keep watching well even after NOT_MODIFIED.
+        """
+        timeout_millis = 1000
+        timeout_second = timeout_millis / 1000
+
+        # pass short timeout millis for testing purpose.
+        watcher: Watcher[Revision] = dogma.repository_watcher(
+            project_name, repo_name, "/**", timeout_millis=timeout_millis)
+
+        # wait until watcher get NOT_MODIFIED at least once.
+        time.sleep(5 * timeout_second)
+
+        commit = Commit("Upsert modify.txt")
+        upsert_text = Change("/path/modify.txt", ChangeType.UPSERT_TEXT, "modified")
+        result = dogma.push(project_name, repo_name, commit, [upsert_text])
+
+        # wait until watcher watch latest.
+        while watcher.latest() is None:
+            time.sleep(timeout_second)
+
+        assert result.revision == watcher.latest().revision.major

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -210,8 +210,7 @@ class TestWatcher:
             assert watcher.latest() == latest
 
     def test_not_modified_repository_watcher(self, run_around_test):
-        """
-        It is for checking the watcher keep watching well even after NOT_MODIFIED.
+        """It verifies that a watcher keep watching well even after `NOT_MODIFIED`.
         """
         timeout_millis = 1000
         timeout_second = timeout_millis / 1000

--- a/tests/test_repository_watcher.py
+++ b/tests/test_repository_watcher.py
@@ -1,0 +1,44 @@
+from unittest.mock import Mock
+
+from centraldogma.data.revision import Revision
+from centraldogma.repository_watcher import RepositoryWatcher
+from centraldogma.watcher import Latest
+
+
+def test__watch():
+    watcher = create_watcher()
+    revision = Revision.init()
+    latest = Latest(revision, watcher.function(revision))
+    watcher._do_watch = Mock(return_value=latest)
+
+    response = watcher._watch(0)
+    assert response == 0
+    assert watcher.latest() == latest
+
+
+def test__watch_with_none_revision():
+    watcher = create_watcher()
+    watcher._do_watch = Mock(return_value=None)
+
+    response = watcher._watch(0)
+    assert response == 0
+    assert watcher.latest() is None
+
+
+def test__watch_with_exception():
+    watcher = create_watcher()
+    watcher._do_watch = Mock(side_effect=Exception("test exception"))
+    response = watcher._watch(0)
+    assert response == 1
+    assert watcher.latest() is None
+
+
+def create_watcher():
+    return RepositoryWatcher(
+        content_service=Mock(),
+        project_name="project",
+        repo_name="repo",
+        path_pattern="/test",
+        timeout_millis=1 * 60 * 1000,
+        function=lambda x: x
+    )

--- a/tests/test_repository_watcher.py
+++ b/tests/test_repository_watcher.py
@@ -40,5 +40,5 @@ def create_watcher():
         repo_name="repo",
         path_pattern="/test",
         timeout_millis=1 * 60 * 1000,
-        function=lambda x: x
+        function=lambda x: x,
     )

--- a/tests/test_repository_watcher.py
+++ b/tests/test_repository_watcher.py
@@ -1,3 +1,17 @@
+#  Copyright 2022 LINE Corporation
+#
+#  LINE Corporation licenses this file to you under the Apache License,
+#  version 2.0 (the "License"); you may not use this file except in compliance
+#  with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
 from unittest.mock import Mock
 
 from centraldogma.data.revision import Revision

--- a/tests/test_repository_watcher.py
+++ b/tests/test_repository_watcher.py
@@ -58,7 +58,7 @@ def test_repository_watch_with_none_revision(repo_watcher, mocker):
     mocker.patch.object(repo_watcher, "_do_watch", return_value=None)
 
     response = repo_watcher._watch(0)
-    assert response == 1
+    assert response == 0
     assert repo_watcher.latest() is None
 
 
@@ -86,7 +86,7 @@ def test_file_watch_with_none_revision(file_watcher, mocker):
     mocker.patch.object(file_watcher, "_do_watch", return_value=None)
 
     response = file_watcher._watch(0)
-    assert response == 1
+    assert response == 0
     assert file_watcher.latest() is None
 
 

--- a/tests/test_repository_watcher.py
+++ b/tests/test_repository_watcher.py
@@ -40,7 +40,7 @@ def file_watcher(mocker):
         repo_name="repo",
         query=Query.text("test.txt"),
         timeout_millis=5000,
-        function=lambda x: x
+        function=lambda x: x,
     )
 
 
@@ -63,7 +63,9 @@ def test_repository_watch_with_none_revision(repo_watcher, mocker):
 
 
 def test_repository_watch_with_exception(repo_watcher, mocker):
-    mocker.patch.object(repo_watcher, "_do_watch", side_effect=Exception("test exception"))
+    mocker.patch.object(
+        repo_watcher, "_do_watch", side_effect=Exception("test exception")
+    )
 
     response = repo_watcher._watch(0)
     assert response == 1
@@ -89,7 +91,9 @@ def test_file_watch_with_none_revision(file_watcher, mocker):
 
 
 def test_file_watch_with_exception(file_watcher, mocker):
-    mocker.patch.object(file_watcher, "_do_watch", side_effect=Exception("test exception"))
+    mocker.patch.object(
+        file_watcher, "_do_watch", side_effect=Exception("test exception")
+    )
 
     response = file_watcher._watch(0)
     assert response == 1


### PR DESCRIPTION
Hi all! I'm really happy to see this project. I'm working on some python project and it use central dogma so this is what I really want!  I've test it in my project and I've found the repository watcher is dead after 304 response.  

I think it because [here](https://github.com/line/centraldogma-python/blob/main/centraldogma/repository_watcher.py#L136). new_latest revision is None when 304 returned so schedule_watch is not triggered. So I moved schedule_watch out from if statement. Could you please check if it makes sense to you? I worried about stackeoverflow but, focused on keeping alive watcher for now.

I look forward to your reply. Thanks!

p.s 저는 한국 개발자입니다. 컨텍스트 공유를 위해 영어로 작성해봤어요. 수고에 진심으로 감사드립니다 :)