### PR TITLE
Deploy Sphinx documentation to Github pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-          pre-build-command: "python -m pip install --upgrade pip && pip install -r requirements.txt"
+          pre-build-command: "python -m pip install --upgrade pip && pip install -r requirements.txt && pip install sphinx_rtd_theme"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-          pre-build-command: "python -m pip install --upgrade pip && pip install sphinx_rtd_theme dataclasses-json httpx[http2]"
+          pre-build-command: "python -m pip install --upgrade pip && pip install -r requirements.txt"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,27 @@
+name: Deploy Sphinx documentation to Github pages
+
+on:
+  push:
+    branches:
+       - main
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "docs/"
+          pre-build-command: "python -m pip install --upgrade pip && pip install sphinx_rtd_theme dataclasses-json httpx[http2]"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: html-docs
+          path: docs/_build/html/
+
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-          pre-build-command: "python -m pip install --upgrade pip && pip install sphinx_rtd_theme dataclasses-json httpx[http2]"
+          pre-build-command: "python -m pip install --upgrade pip && pip install -r requirements.txt"
 
   linter:
     name: black --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-          pre-build-command: "python -m pip install --upgrade pip && pip install -r requirements.txt"
+          pre-build-command: "python -m pip install --upgrade pip && pip install -r requirements.txt && pip install sphinx_rtd_theme"
 
   linter:
     name: black --check

--- a/centraldogma/repository_watcher.py
+++ b/centraldogma/repository_watcher.py
@@ -1,16 +1,16 @@
-#  Copyright 2021 LINE Corporation
+# Copyright 2021 LINE Corporation
 #
-#  LINE Corporation licenses this file to you under the Apache License,
-#  version 2.0 (the "License"); you may not use this file except in compliance
-#  with the License. You may obtain a copy of the License at:
+# LINE Corporation licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
 #
-#    https://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#  License for the specific language governing permissions and limitations
-#  under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
 import itertools
 import logging
 import math


### PR DESCRIPTION
Motivation
- Unless users build Sphinx at local, there was no way to see documentation.

Modifications
- Add a Github action to deploy to Github pages.
  - It tested at forked repo. https://hexoul.github.io/centraldogma-python/centraldogma.html#module-centraldogma.dogma
- misc.
  - Fix pre-build command for Sphinx.
  - Fix wrong spaces.

Result
- Deployed Github pages.