### PR TITLE
Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <img src="https://badge.fury.io/py/centraldogma-python.svg" alt="Package version">
 </a>
 
-Python client library for [Central Dogma](https://line.github.io/centraldogma/)
+Python client library for [Central Dogma](https://line.github.io/centraldogma/).
 
 ## Install
 ```
@@ -30,25 +30,25 @@ $ pytest
 
 #### Integration test
 1. Run local Central Dogma server with docker-compose
-```
-$ docker-compose up -d
-```
+    ```
+    $ docker-compose up -d
+    ```
 
 2. Run integration tests
-```
-$ INTEGRATION_TEST=true pytest
-```
+    ```
+    $ INTEGRATION_TEST=true pytest
+    ```
 
 3. Stop the server
-```
-$ docker-compose down
-```
+    ```
+    $ docker-compose down
+    ```
 
 ### Lint
 - [PEP 8](https://www.python.org/dev/peps/pep-0008)
-```
-$ black .
-```
+    ```
+    $ black .
+    ```
 
 ### Documentation
 - [PEP 257](https://www.python.org/dev/peps/pep-0257)

--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -227,9 +227,8 @@ class Dogma:
     ) -> Optional[Entry[T]]:
         """Waits for the file matched by the specified ``Query`` to be changed since the specified
         ``last_known_revision``. If no changes were made within the specified ``timeout_millis``,
-        ``None`` will be returned.
-        It is recommended to specify the largest ``timeout_millis`` allowed by the server. If unsure, use
-        the default watch timeout.
+        ``None`` will be returned. It is recommended to specify the largest ``timeout_millis`` allowed by the server.
+        If unsure, use the default watch timeout.
 
         :return: the ``Entry`` which contains the latest known ``Query`` result.
             ``None`` if the file was not changed for ``timeout_millis`` milliseconds
@@ -253,7 +252,6 @@ class Dogma:
                 return dogma.get_files("foo_project", "bar_repo", revision, "/*.json")
 
             with dogma.repository_watcher("foo_project", "bar_repo", "/*.json", get_files) as watcher:
-
                 def listener(revision: Revision, contents: List[Content]) -> None:
                     ...
 
@@ -292,7 +290,6 @@ class Dogma:
 
            with dogma.file_watcher("foo_project", "bar_repo", Query.json("/baz.json"),
                                    lambda content: MyType.from_dict(content)) as watcher:
-
                def listener(revision: Revision, value: MyType) -> None:
                    ...
 

--- a/centraldogma/dogma.py
+++ b/centraldogma/dogma.py
@@ -127,10 +127,10 @@ class Dogma:
         :param path_pattern: A path pattern is a variant of glob as follows. |br|
             "/\*\*" - find all files recursively |br|
             "\*.json" - find all JSON files recursively |br|
-            "/foo/\*.json" - find all JSON files under the directory /foo |br|
+            "/foo/\*.json" - find all JSON files under the directory ``/foo`` |br|
             "/\*/foo.txt" - find all files named foo.txt at the second depth level |br|
             "\*.json,/bar/\*.txt" - use comma to match any patterns |br|
-            This will bring all of the files in the repository, if unspecified. |br|
+            This will bring all of the files in the repository, if unspecified.
         :param revision: The revision of the list to get. If not specified, gets the list of
             the latest revision.
         """
@@ -153,7 +153,7 @@ class Dogma:
             "\*.json" - find all JSON files recursively |br|
             "/foo/\*.json" - find all JSON files under the directory /foo |br|
             "/\*/foo.txt" - find all files named foo.txt at the second depth level |br|
-            "\*.json,/bar/\*.txt" - use comma to match any patterns
+            "\*.json,/bar/\*.txt" - use comma to match any patterns |br|
             This will bring all of the files in the repository, if unspecified.
         :param revision: The revision of the list to get. If not specified, gets the list of
             the latest revision.
@@ -206,9 +206,8 @@ class Dogma:
     ) -> Optional[Revision]:
         """Waits for the files matched by the specified ``path_pattern`` to be changed since the specified
         ``last_known_revision``. If no changes were made within the specified ``timeout_millis``,
-        ``None`` will be returned.
-        It is recommended to specify the largest ``timeout_millis`` allowed by the server. If unsure, use
-        the default watch timeout.
+        ``None`` will be returned. It is recommended to specify the largest ``timeout_millis`` allowed by the server.
+        If unsure, use the default watch timeout.
 
         :return: the latest known ``Revision`` which contains the changes for the matched files.
             ``None`` if the files were not changed for ``timeout_millis`` milliseconds
@@ -324,7 +323,7 @@ class Dogma:
         """Returns the merged result of files represented by ``MergeSource``. Each ``MergeSource``
         can be optional, indicating that no error should be thrown even if the path doesn't exist.
         If ``json_paths`` is specified, each ``json_path`` is applied recursively on the merged
-        result. If any of the ``json_path``s is invalid, a ``QueryExecutionException`` is thrown.
+        result. If any of the ``json_path`` s is invalid, a ``QueryExecutionException`` is thrown.
 
         :raises ValueError: If the provided ``merge_sources`` is empty.
         :return: the ``MergedEntry`` which contains the merged content for the given query.

--- a/centraldogma/watcher.py
+++ b/centraldogma/watcher.py
@@ -11,7 +11,6 @@
 #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #  License for the specific language governing permissions and limitations
 #  under the License.
-
 from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import TypeVar, Generic, Callable

--- a/docs/centraldogma.data.rst
+++ b/docs/centraldogma.data.rst
@@ -20,14 +20,6 @@ centraldogma.data.commit module
    :undoc-members:
    :show-inheritance:
 
-centraldogma.data.constants module
-----------------------------------
-
-.. automodule:: centraldogma.data.constants
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 centraldogma.data.content module
 --------------------------------
 
@@ -40,6 +32,30 @@ centraldogma.data.creator module
 --------------------------------
 
 .. automodule:: centraldogma.data.creator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.data.entry module
+----------------------------------
+
+.. automodule:: centraldogma.data.entry
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.data.merge\_source module
+----------------------------------
+
+.. automodule:: centraldogma.data.merge_source
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.data.merged\_entry module
+----------------------------------
+
+.. automodule:: centraldogma.data.merged_entry
    :members:
    :undoc-members:
    :show-inheritance:
@@ -68,10 +84,10 @@ centraldogma.data.repository module
    :undoc-members:
    :show-inheritance:
 
-Module contents
----------------
+centraldogma.data.revision module
+-----------------------------------
 
-.. automodule:: centraldogma.data
+.. automodule:: centraldogma.data.revision
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/centraldogma.rst
+++ b/docs/centraldogma.rst
@@ -1,45 +1,10 @@
 centraldogma package
 ====================
 
-Subpackages
------------
-
-.. toctree::
-   :maxdepth: 4
-
-   centraldogma.data
-
-Submodules
-----------
-
-centraldogma.base\_client module
---------------------------------
-
-.. automodule:: centraldogma.base_client
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-centraldogma.content\_service module
-------------------------------------
-
-.. automodule:: centraldogma.content_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 centraldogma.dogma module
 -------------------------
 
 .. automodule:: centraldogma.dogma
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-centraldogma.exceptions module
-------------------------------
-
-.. automodule:: centraldogma.exceptions
    :members:
    :undoc-members:
    :show-inheritance:
@@ -60,13 +25,45 @@ centraldogma.repository\_service module
    :undoc-members:
    :show-inheritance:
 
-Module contents
----------------
+centraldogma.content\_service module
+------------------------------------
 
-.. automodule:: centraldogma
+.. automodule:: centraldogma.content_service
    :members:
    :undoc-members:
    :show-inheritance:
+
+centraldogma.watcher module
+--------------------------------
+
+.. automodule:: centraldogma.watcher
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.query module
+--------------------------------
+
+.. automodule:: centraldogma.query
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+centraldogma.exceptions module
+------------------------------
+
+.. automodule:: centraldogma.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   centraldogma.data
 
 .. |br| raw:: html
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,8 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "centraldogma-python"
-copyright = "2022, hexoul, ikhoon, minwoox"
-author = "hexoul, ikhoon, minwoox"
+copyright = "2017-2022, LINE Corporation"
+author = "Central Dogma Team"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Motivation
- Wrong formatting.
  - <img width="400" alt="before1" src="https://user-images.githubusercontent.com/11401808/192347644-2f78badb-9ada-4692-a435-b7dd79315904.png">
  - <img width="400" alt="before2" src="https://user-images.githubusercontent.com/11401808/192347653-94954980-1e5b-449b-b700-037a0c3d9499.png">
- Missing modules in Sphinx. e.g. `centraldogma.watcher`, `centraldogma.data.entry` and so on.

Modifications
- Fix indentations in README.
- Order packages properly in Sphinx.
- Add missing modules in Sphinx.
- Fix copyright and authors in Sphinx.

Result
- You can compare with https://line.github.io/centraldogma-python/.
  - <img width="500" alt="after1" src="https://user-images.githubusercontent.com/11401808/192348327-4c1cb8b2-33e9-4911-9963-db3fe5ad0758.png">
  - <img width="500" alt="스크린샷 2022-09-27 오전 3 05 40" src="https://user-images.githubusercontent.com/11401808/192348675-21641b9b-613f-49df-a19f-10f54d750e8c.png">

