### PR TITLE
Update Github actions to test more Python versions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ammaraskar/sphinx-action@master
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
+        cache: "pip"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Build and publish
       env:
-        TWINE_USERNAME: "__token__" # https://github.com/pypa/twine/blob/main/tests/test_integration.py#L46-L66
+        TWINE_USERNAME: "__token__" # https://github.com/pypa/twine/blob/3.x/tests/test_integration.py#L53-L64
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_CENTRALDOGMA }}
       run: |
         python setup.py sdist bdist_wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,6 @@ on:
        - main
   pull_request:
 
-env:
-  python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -34,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ${{ env.python-version }}
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9"]
 
     steps:
       - uses: actions/checkout@v3
@@ -68,7 +65,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: ${{ env.python-version }}
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,10 @@ jobs:
         run: docker-compose -f "docker-compose.yml" up -d --build
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
       - name: Install dependencies
         run: |
@@ -72,9 +73,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,14 @@ on:
        - main
   pull_request:
 
+env:
+  python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
@@ -20,7 +23,7 @@ jobs:
     name: black --check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: rickstaa/action-black@v1
         id: action_black
         with:
@@ -31,10 +34,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ${{ env.python-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Start Central Dogma
         run: docker-compose -f "docker-compose.yml" up -d --build
 
@@ -64,10 +67,10 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ${{ env.python-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tests/integration/test_watcher.py
+++ b/tests/integration/test_watcher.py
@@ -79,7 +79,6 @@ class TestWatcher:
             assert result.revision == watched_revision.major
 
     def test_file_watcher(self, run_around_test):
-
         commit = Commit("Upsert1 test.json")
         upsert_text = Change(
             "/test.json", ChangeType.UPSERT_JSON, {"a": 1, "b": 2, "c": 3}
@@ -196,7 +195,6 @@ class TestWatcher:
             Query.json("/foo.json"),
             lambda j: json.dumps(j),
         ) as watcher:
-
             future: Future[Latest[str]] = watcher.initial_value_future()
             with pytest.raises(TimeoutError):
                 future.result(timeout=1)


### PR DESCRIPTION
Motivation
--
- Test the library on more Python versions.

Modifications
--
- Add `3.11`, `pypy3.8` and `pypy3.9` to testing environments.
- misc.
  - Bump dependencies used in Github actions.
  - Use pip cache.

Result
--
- Ensure that it also works on `3.11`, `pypy3.8` and `pypy3.9`.