### PR TITLE
Expose useful configurations with agnostic way

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ammaraskar/sphinx-action@master
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
         cache: "pip"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Start Central Dogma
-        run: docker-compose -f "docker-compose.yml" up -d --build
+        run: docker compose -f "docker-compose.yml" up -d --build
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -58,7 +58,7 @@ jobs:
 
       - name: Stop containers
         if: always()
-        run: docker-compose -f "docker-compose.yml" down
+        run: docker compose -f "docker-compose.yml" down
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
@@ -20,7 +20,7 @@ jobs:
     name: black --check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: rickstaa/action-black@v1
         id: action_black
         with:
@@ -34,12 +34,12 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Start Central Dogma
         run: docker-compose -f "docker-compose.yml" up -d --build
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -68,9 +68,9 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -11,12 +11,20 @@ $ pip install centraldogma-python
 ```
 
 ## Getting started
+Only URL indicating CentralDogma server and access token are required.
 ```pycon
 >>> from centraldogma.dogma import Dogma
 >>> dogma = Dogma("https://dogma.yourdomain.com", "token")
 >>> dogma.list_projects()
 []
 ```
+
+It supports client configurations.
+```pycon
+>>> retries, max_connections = 5, 10
+>>> dogma = Dogma("https://dogma.yourdomain.com", "token", retries=retries, max_connections=max_connections)
+```
+
 Please see [`examples` folder](https://github.com/line/centraldogma-python/tree/main/examples) for more detail.
 
 ---

--- a/centraldogma/base_client.py
+++ b/centraldogma/base_client.py
@@ -28,9 +28,9 @@ class BaseClient:
         base_url: str,
         token: str,
         http2: bool = True,
-        retries: int = 0,
-        max_connections: int = 100,
-        max_keepalive_connections: int = 20,
+        retries: int = 1,
+        max_connections: int = 10,
+        max_keepalive_connections: int = 2,
         **configs,
     ):
         base_url = base_url[:-1] if base_url[-1] == "/" else base_url

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -15,7 +15,7 @@ from http import HTTPStatus
 
 from centraldogma.exceptions import UnauthorizedException, NotFoundException
 from centraldogma.base_client import BaseClient
-from httpx import Limits, Response
+from httpx import Response
 import pytest
 
 client = BaseClient("http://baseurl", "token")
@@ -28,7 +28,9 @@ configs = {
     "proxies": None,
     "mounts": None,
     "timeout": 5,
-    "limits": Limits(max_connections=100, max_keepalive_connections=20),
+    "retries": 10,
+    "max_connections": 50,
+    "max_keepalive_connections": 10,
     "max_redirects": 1,
     "event_hooks": None,
     "transport": None,


### PR DESCRIPTION
Motivation
- Prior to support complete functionality of automatic retry, agnostic client makes it easy to use.
- #46 

Modifications
- Expose useful configurations, `retries`, `max_connections` and `max_keepalive_connections`. Default values are [same with httpx](https://www.python-httpx.org/advanced/resource-limits/).
- misc.
  - Leave TODO to consecutive work for automatic retry.
  - Upgrade Github action versions.
  - Revise README.

Result
- Dogma client become a little bit more agnostic.
