### PR TITLE
update supported python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9"]
 
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11","3.12", "pypy3.8", "pypy3.9"]
 
     steps:
       - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license="Apache License 2.0",
     packages=["centraldogma", "centraldogma.data"],
     install_requires=get_install_requires(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     keywords="centraldogma",
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -51,11 +51,11 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )


### PR DESCRIPTION
update supported python versions in CI
- remove python 3.7 end of life 
- add python 3.12 released last year
- refer https://devguide.python.org/versions/ 