### PR TITLE
remove version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   centraldogma:
     image: line/centraldogma:latest


### PR DESCRIPTION
`version` is obsolete in `docker-compose.yml` 

[Version top-level element (obsolete)](https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-and-name-top-level-elements)