### PR TITLE
Bug fix from get_files method.

### DIFF
--- a/centraldogma/content_service.py
+++ b/centraldogma/content_service.py
@@ -56,9 +56,13 @@ class ContentService:
                 path += "/" + path_pattern
 
         handler = {
-            HTTPStatus.OK: lambda resp: [
-                Content.from_dict(content) for content in resp.json()
-            ],
+            HTTPStatus.OK: lambda resp: (
+                lambda data: (
+                    [Content.from_dict(content) for content in data]
+                    if isinstance(data, list)
+                    else [Content.from_dict(data)]
+                )
+            )(resp.json()),
             HTTPStatus.NO_CONTENT: lambda resp: [],
         }
         return self.client.request("get", path, params=params, handler=handler)

--- a/tests/integration/test_content_service.py
+++ b/tests/integration/test_content_service.py
@@ -241,6 +241,44 @@ class TestContentService:
         assert ret.entry_type == EntryType.JSON
         assert ret.content == {"foo3": "bar3"}
 
+    def test_when_cd_has_a_file_and_get_files_is_called_it_should_be_failed(
+        self, run_around_test
+    ):
+        # GIVEN
+        commit = Commit("Upsert dummy1-test.json")
+        upsert_json = Change(
+            "/test/dummy1-test.json", ChangeType.UPSERT_JSON, {"foo": "bar"}
+        )
+        dogma.push(project_name, repo_name, commit, [upsert_json])
+
+        # WHEN + THEN
+        with pytest.raises(AttributeError):
+            dogma.get_files(project_name, repo_name, "/test/dummy1-test.json")
+
+    def test_when_cd_has_two_files_and_get_files_is_called_it_should_be_success(
+        self, run_around_test
+    ):
+        # GIVEN
+        expected_file_count = 2
+
+        commit = Commit("Upsert dummy1-test.json")
+        upsert_json = Change(
+            "/dummy1-test.json", ChangeType.UPSERT_JSON, {"foo": "bar"}
+        )
+        dogma.push(project_name, repo_name, commit, [upsert_json])
+
+        commit = Commit("Upsert dummy2-test.json")
+        upsert_json = Change(
+            "/dummy2-test.json", ChangeType.UPSERT_JSON, {"foo": "bar"}
+        )
+        dogma.push(project_name, repo_name, commit, [upsert_json])
+
+        # WHEN
+        result = dogma.get_files(project_name, repo_name, "/dummy*-test.json")
+
+        # THEN
+        assert len(result) == expected_file_count
+
     @staticmethod
     def push_later():
         time.sleep(1)

--- a/tests/integration/test_content_service.py
+++ b/tests/integration/test_content_service.py
@@ -252,7 +252,6 @@ class TestContentService:
         assert len(ret) == 1
 
     def test_get_files_for_multiple_file(self, run_around_test):
-
         commit = Commit("Upsert dummy1-test.json")
         upsert_json = Change(
             "/dummy1-test.json", ChangeType.UPSERT_JSON, {"foo": "bar"}

--- a/tests/integration/test_content_service.py
+++ b/tests/integration/test_content_service.py
@@ -241,25 +241,17 @@ class TestContentService:
         assert ret.entry_type == EntryType.JSON
         assert ret.content == {"foo3": "bar3"}
 
-    def test_when_cd_has_a_file_and_get_files_is_called_it_should_be_failed(
-        self, run_around_test
-    ):
-        # GIVEN
+    def test_get_files_for_single_file(self, run_around_test):
         commit = Commit("Upsert dummy1-test.json")
         upsert_json = Change(
             "/test/dummy1-test.json", ChangeType.UPSERT_JSON, {"foo": "bar"}
         )
         dogma.push(project_name, repo_name, commit, [upsert_json])
 
-        # WHEN + THEN
-        with pytest.raises(AttributeError):
-            dogma.get_files(project_name, repo_name, "/test/dummy1-test.json")
+        ret = dogma.get_files(project_name, repo_name, "/test/dummy1-test.json")
+        assert len(ret) == 1
 
-    def test_when_cd_has_two_files_and_get_files_is_called_it_should_be_success(
-        self, run_around_test
-    ):
-        # GIVEN
-        expected_file_count = 2
+    def test_get_files_for_multiple_file(self, run_around_test):
 
         commit = Commit("Upsert dummy1-test.json")
         upsert_json = Change(
@@ -273,11 +265,8 @@ class TestContentService:
         )
         dogma.push(project_name, repo_name, commit, [upsert_json])
 
-        # WHEN
-        result = dogma.get_files(project_name, repo_name, "/dummy*-test.json")
-
-        # THEN
-        assert len(result) == expected_file_count
+        ret = dogma.get_files(project_name, repo_name, "/dummy*-test.json")
+        assert len(ret) == 2
 
     @staticmethod
     def push_later():


### PR DESCRIPTION
### Background
`content_service.get_files()` has potential bugs. because it uses `httpx.client()`.

I assume the following scenario.
I send a request to `Central Dogma` with pattern `/*s.json`. 
There are three possible cases

- Case1. If multiple files are found, `httpx.client.json()` returns a `list[dict[str, str]]`. 
- Case2. If only one file is found, `httpx.client.json()` returns a `dict[str,str]`
- Case3. No contents

In case2, the Central Dogma client throws an unexpected error.
Because `Content.from_dict(content)` receives an unexpected argument of type `str`.