### PR TITLE
docs: Upgrade Github actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,9 +1,8 @@
 name: Deploy Sphinx documentation to Github pages
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [created]
 
 env:
   UV_SYSTEM_PYTHON: 1
@@ -21,9 +20,7 @@ jobs:
           python-version: 3.13
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: "0.5.1"
+        uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
         run: uv pip install -e '.[docs]'
@@ -31,12 +28,12 @@ jobs:
       - name: Build docs
         run: sphinx-build docs ./docs/_build/html/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: html-docs
           path: docs/_build/html/
 
-      - uses: peaceiris/actions-gh-pages@v3
+      - uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "centraldogma-python"
-copyright = "2017-2024, LINE Corporation"
+copyright = "2017-2025, LINE Corporation"
 author = "Central Dogma Team"
 
 


### PR DESCRIPTION
Motivation
- It uses a deprecated version of `actions/upload-artifact:v3`. The action prohibit the use so we cannot publish now until fixed.
- A trigger for documentation would be better to be changed to releases rather than main push.

Modifications
- Upgrade `actions/upload-artifact` from v3 to v4.
- The trigger is changed from `push:branches:main` to `release:types:[created]`.
- misc.
  - Upgrade `astral-sh/setup-uv` from v3 to v5. To use latest version of uv, delete specific version.
  - Upgrade `peaceiris/actions-gh-pages` from v3 to v4.
  - Update copyright.

Result
- Close #60 